### PR TITLE
Prevented PHP error

### DIFF
--- a/lib/Mautic/Auth/OAuth.php
+++ b/lib/Mautic/Auth/OAuth.php
@@ -623,9 +623,15 @@ class OAuth extends ApiAuth implements AuthInterface
             CURLOPT_URL            => $url,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYPEER => false,
-            CURLOPT_HEADER         => true,
-            CURLOPT_FOLLOWLOCATION => true
+            CURLOPT_HEADER         => true
         );
+
+        // CURLOPT_FOLLOWLOCATION cannot be activated when an open_basedir is set
+        if (ini_get('open_basedir')) {
+            $options[CURLOPT_HTTPHEADER] = true;
+        } else {
+            $options[CURLOPT_HTTPHEADER] = false;
+        }
 
         //Set CURL headers for oauth 1.0 requests
         if ($this->isOauth1()) {

--- a/lib/Mautic/Auth/OAuth.php
+++ b/lib/Mautic/Auth/OAuth.php
@@ -628,9 +628,9 @@ class OAuth extends ApiAuth implements AuthInterface
 
         // CURLOPT_FOLLOWLOCATION cannot be activated when an open_basedir is set
         if (ini_get('open_basedir')) {
-            $options[CURLOPT_HTTPHEADER] = true;
+            $options[CURLOPT_FOLLOWLOCATION] = false;
         } else {
-            $options[CURLOPT_HTTPHEADER] = false;
+            $options[CURLOPT_FOLLOWLOCATION] = true;
         }
 
         //Set CURL headers for oauth 1.0 requests


### PR DESCRIPTION
This PR prevents PHP error with message: 

```CURLOPT_FOLLOWLOCATION cannot be activated when an open_basedir is set```

I got this error on my shared host.