### PR TITLE
Fixes bad DELETE requests and some quirky issues with the api tester

### DIFF
--- a/apitester/index.php
+++ b/apitester/index.php
@@ -12,8 +12,8 @@ if (empty($auth)) {
 }
 $apiurl             = (isset($_POST['apiurl'])) ? $_POST['apiurl'] : @$_SESSION['apiurl'];
 $_SESSION['apiurl'] = $apiurl;
-if (!empty($apiurl) && substr($apiurl, -1)) {
-    $apiUrl .= '/';
+if (!empty($apiurl) && substr($apiurl, -1) == '/') {
+    $apiurl = substr($apiurl, 0, -1);
 }
 
 //clear the debug info
@@ -37,11 +37,8 @@ $getCurrentUrl = function () {
 };
 
 //OAuth1a
-$oauthBaseUrl = str_replace('/api', '', $apiurl);
-if (!empty($oauthBaseUrl) && substr($oauthBaseUrl, -1) == '/') {
-    $oauthBaseUrl = substr($oauthBaseUrl, 0, -1);
-}
-$getOauth1Value = function ($key) use ($getCurrentUrl, $oauthBaseUrl) {
+$oauthBaseUrl   = $apiurl;
+$getOauth1Value = function($key) use ($getCurrentUrl, $oauthBaseUrl) {
 
     switch ($key) {
         case 'callback':
@@ -113,6 +110,7 @@ $method      = (isset($_POST['method'])) ? $_POST['method'] : @$_SESSION['method
 if (empty($method)) {
     $method = "GET";
 }
+
 $responsetype = (isset($_POST['responsetype'])) ? $_POST['responsetype'] : @$_SESSION['responsetype'];
 if (empty($responsetype)) {
     $responsetype = '/';
@@ -216,8 +214,7 @@ if (isset($_SESSION['redirect'])) {
                 }
 
                 if (!empty($_POST['apiurl'])) {
-                    $url = $apiurl.'api/'.$apiendpoint;
-
+                    $url = $apiurl . '/api/' . $apiendpoint;
                     if ($responsetype != '/') {
                         $url .= $responsetype;
                     }
@@ -244,13 +241,13 @@ if (isset($_SESSION['redirect'])) {
 
             if (!empty($response)) {
                 if (is_array($response)) {
-                    $output .= "<p>".@Kint::dump($response)."</p>";
+                    $output .= @Kint::dump($response);
                 } else {
-                    $output .= "<p>$response</p>";
+                    $output .= $response;
                 }
             }
         } catch (Exception $e) {
-            $output = '<div class="text-danger">'.$e->getMessage().'</div>';
+            $output .= '<div class="text-danger">'.$e->getMessage().'</div>';
         }
 
         $output .= @Kint::dump($_SESSION[$auth]);
@@ -318,7 +315,7 @@ echo <<<ENDPOINT
             var {$endpoint}Endpoint = new Bloodhound({
               datumTokenizer: Bloodhound.tokenizers.obj.whitespace('endpoint'),
               queryTokenizer: Bloodhound.tokenizers.whitespace,
-              remote: {
+              prefetch: {
                     url: 'endpoints/$file',
                     filter: function(list) {
                         return $.map(list, function(ep) { return { endpoint: ep }; });

--- a/lib/Auth/OAuth.php
+++ b/lib/Auth/OAuth.php
@@ -13,7 +13,11 @@ use Mautic\Exception\IncorrectParametersReturnedException;
 use Mautic\Exception\UnexpectedResponseFormatException;
 
 /**
+ * Class OAuth
+ *
  * OAuth Client modified from https://code.google.com/p/simple-php-oauth/
+ *
+ * @package Mautic\Auth
  */
 class OAuth extends ApiAuth implements AuthInterface
 {
@@ -714,7 +718,6 @@ class OAuth extends ApiAuth implements AuthInterface
         //Set custom REST method if not GET or POST
         if (!in_array($method, array('GET', 'POST'))) {
             $options[CURLOPT_CUSTOMREQUEST] = $method;
-            $options[CURLOPT_POSTFIELDS]    = http_build_query($parameters);
         }
 
         //Set post fields for POST/PUT/PATCH requests


### PR DESCRIPTION
DELETE requests failed because the parameters were set as CURLOPT_POSTFIELDS which the oauth server rejected (related to the failed testCreateAndDelete mentioned in #3). Fixed the issue by removing the line of code that set the post fields non get/post methods (post, put and patch sets this later in the code). 

This also fixes a few quirky issues with the api tester where ending / in the URLs was inconsistent and caused problems, the endpoint typeahead not filtering (it highlighted but did not filter), and the response output did not show.