### PR TITLE
Add OAuth1a spec support to tests

### DIFF
--- a/tests/Api/MauticApiTestCase.php
+++ b/tests/Api/MauticApiTestCase.php
@@ -16,13 +16,13 @@ abstract class MauticApiTestCase extends \PHPUnit_Framework_TestCase
 {
     protected function getAuth()
     {
-        include __DIR__.'/../local.config.php';
+        $parameters = include __DIR__.'/../local.config.php';
 
-        $auth = ApiAuth::initiate(array('accessToken' => $accessToken));
+        $auth = ApiAuth::initiate($parameters);
 
         $this->assertTrue($auth->isAuthorized(), 'Authorization failed. Check credentials in local.config.php.');
 
-        return array($auth, $apiUrl);
+        return array($auth, $parameters['apiUrl']);
     }
 
     protected function getContext($context)

--- a/tests/local.config.php.dist
+++ b/tests/local.config.php.dist
@@ -5,7 +5,7 @@ return array(
     'apiUrl'          => 'http://example.com/index_dev.php/api/',
 
     // Required only for OAuth 1a testing
-    'requestTokenUrl' => 'http://example.com', // Can be set to anything which will force the OAuth library to use the 1.0a spec
+    'requestTokenUrl' => '', // Set with any string to force the library to use the OAuth1.a spec; leave blank to use OAuth2
     'clientKey'       => '',
     'clientSecret'    => '',
     'callback'        => ''

--- a/tests/local.config.php.dist
+++ b/tests/local.config.php.dist
@@ -1,5 +1,12 @@
 <?php
-$clientId     = '';
-$clientSecret = '';
-$accessToken  = '';
-$apiUrl       = 'http://example.com/index_dev.php/api/';
+return array(
+    // Required for both OAuth 1a and 2 testing
+    'accessToken'     => '',
+    'apiUrl'          => 'http://example.com/index_dev.php/api/',
+
+    // Required only for OAuth 1a testing
+    'requestTokenUrl' => 'http://example.com', // Can be set to anything which will force the OAuth library to use the 1.0a spec
+    'clientKey'       => '',
+    'clientSecret'    => '',
+    'callback'        => ''
+);


### PR DESCRIPTION
This adds support for using the OAuth1a spec for tests. Refer to the local.config.php.dist file for the changes needed.