### PR TITLE
New lead endpoints

### DIFF
--- a/apitester/endpoints/Leads.json
+++ b/apitester/endpoints/Leads.json
@@ -5,5 +5,7 @@
     "leads/list/owners",
     "leads/new",
     "leads/edit/{id}",
-    "leads/notes"
+    "leads/{id}/notes",
+    "leads/{id}/lists",
+    "leads/{id}/campaigns"
 ]

--- a/lib/Api/Api.php
+++ b/lib/Api/Api.php
@@ -154,7 +154,7 @@ class Api
     /**
      * Get a list of items
      *
-     * @param string $filter
+     * @param string $search
      * @param int    $start
      * @param int    $limit
      * @param string $orderBy
@@ -163,11 +163,11 @@ class Api
      *
      * @return array|mixed
      */
-    public function getList($filter = '', $start = 0, $limit = 0, $orderBy = '', $orderByDir = 'ASC', $publishedOnly = false)
+    public function getList($search = '', $start = 0, $limit = 0, $orderBy = '', $orderByDir = 'ASC', $publishedOnly = false)
     {
         $parameters = array();
 
-        $args = array('filter', 'start', 'limit', 'orderBy', 'orderByDir', 'publishedOnly');
+        $args = array('search', 'start', 'limit', 'orderBy', 'orderByDir', 'publishedOnly');
 
         foreach ($args as $arg) {
             if (!empty($$arg)) {
@@ -181,7 +181,7 @@ class Api
     /**
      * Proxy function to getList with $publishedOnly set to true
      *
-     * @param string $filter
+     * @param string $search
      * @param int    $start
      * @param int    $limit
      * @param string $orderBy
@@ -189,9 +189,9 @@ class Api
      *
      * @return array|mixed
      */
-    public function getPublishedList($filter = '', $start = 0, $limit = 0, $orderBy = '', $orderByDir = 'ASC')
+    public function getPublishedList($search = '', $start = 0, $limit = 0, $orderBy = '', $orderByDir = 'ASC')
     {
-        return $this->getList($filter, $start, $limit, $orderBy, $orderByDir, true);
+        return $this->getList($search, $start, $limit, $orderBy, $orderByDir, true);
     }
 
     /**

--- a/lib/Api/Leads.php
+++ b/lib/Api/Leads.php
@@ -51,14 +51,50 @@ class Leads extends Api
     }
 
     /**
-     * Get the notes on a lead
+     * Get a list of a lead's notes
      *
-     * @param int $id ID of lead
+     * @param int    $id Lead ID
+     * @param string $search
+     * @param int    $start
+     * @param int    $limit
+     * @param string $orderBy
+     * @param string $orderByDir
+     * @param bool   $publishedOnly
      *
      * @return array|mixed
      */
-    public function getNotes($id)
+    public function getLeadNotes($id, $search = '', $start = 0, $limit = 0, $orderBy = '', $orderByDir = 'ASC')
     {
-        return $this->makeRequest('leads/'.$id.'/notes');
+        $parameters = array();
+
+        $args = array('search', 'start', 'limit', 'orderBy', 'orderByDir');
+
+        foreach ($args as $arg) {
+            if (!empty($$arg)) {
+                $parameters[$arg] = $$arg;
+            }
+        }
+
+        return $this->makeRequest('leads/'.$id.'/notes', $parameters);
+    }
+
+    /**
+     * Get a list of smart lists the lead is in
+     *
+     * @param $id
+     */
+    public function getLeadLists($id)
+    {
+        return $this->makeRequest('leads/'.$id.'/lists');
+    }
+
+    /**
+     * Get a list of campaigns the lead is in
+     *
+     * @param $id
+     */
+    public function getLeadCampaigns($id)
+    {
+        return $this->makeRequest('leads/'.$id.'/campaigns');
     }
 }

--- a/tests/Api/LeadsTest.php
+++ b/tests/Api/LeadsTest.php
@@ -50,7 +50,25 @@ class LeadsTest extends MauticApiTestCase
     public function testGetNotes()
     {
         $leadApi = $this->getContext('leads');
-        $leads   = $leadApi->getNotes(1);
+        $leads   = $leadApi->getLeadNotes(1);
+
+        $message = isset($leads['error']) ? $leads['error']['message'] : '';
+        $this->assertFalse(isset($leads['error']), $message);
+    }
+
+    public function testGetLists()
+    {
+        $leadApi = $this->getContext('leads');
+        $leads   = $leadApi->getLeadLists(1);
+
+        $message = isset($leads['error']) ? $leads['error']['message'] : '';
+        $this->assertFalse(isset($leads['error']), $message);
+    }
+
+    public function testGetCampaigns()
+    {
+        $leadApi = $this->getContext('leads');
+        $leads   = $leadApi->getLeadCampaigns(1);
 
         $message = isset($leads['error']) ? $leads['error']['message'] : '';
         $this->assertFalse(isset($leads['error']), $message);


### PR DESCRIPTION
This adds support for the new endpoints /leads/{id}/lists and /leads/{id}/campaigns (companion to https://github.com/mautic/mautic/pull/246), added filtering parameters to getLeadNotes (changed from getNotes to getLeadNotes to match the two new functions), and changes the 'filter' parameter to 'search' which is what the API now accepts.