### PR TITLE
Unignore tests/bootstrap.php

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,4 @@
 /phpunit.xml
 /tests/local.config.php
 /tests/phpunit.phar
-/tests/bootstrap.php
 /vendor

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,20 @@
+<?php
+// Ensure a test config exists
+$configPath = __DIR__ . '/local.config.php';
+
+if (!file_exists($configPath)) {
+    fwrite(STDOUT, "A local config file does not exist.  Please create one.  You can use the file at ".__DIR__."/local.config.php.dist as a starting point.\n");
+
+    exit;
+}
+
+// Load the Composer autoloader
+$autoloadPath = dirname(__DIR__).'/vendor/autoload.php';
+
+if (!file_exists($autoloadPath)) {
+    fwrite(STDOUT, "Composer is not set up properly, please run 'composer install'.\n");
+
+    exit;
+}
+
+require $autoloadPath;


### PR DESCRIPTION
This takes the `tests/bootstrap.php` file out of the gitignore list and adds a bootstrap file.  This file checks for the existence of a `tests/local.config.php` file and that the Composer dependencies have been installed prior to executing PHPUnit and aborts the test run if either of these conditions are not met.