### PR TITLE
Appended the callback to the authorize URL for OAuth1a

### DIFF
--- a/lib/Auth/OAuth.php
+++ b/lib/Auth/OAuth.php
@@ -616,6 +616,11 @@ class OAuth extends ApiAuth implements AuthInterface
         if ($this->isOauth1()) {
             //OAuth 1.0
             $authUrl .= '?oauth_token='.$_SESSION['oauth']['token'];
+
+            if (!empty($this->_callback)) {
+                $authUrl .= '&oauth_callback=' . urlencode($this->_callback);
+            }
+
         } else {
             //OAuth 2.0
             $authUrl .= '?client_id='.$this->_client_id.'&redirect_uri='.$this->_callback;

--- a/lib/Auth/OAuth.php
+++ b/lib/Auth/OAuth.php
@@ -431,7 +431,7 @@ class OAuth extends ApiAuth implements AuthInterface
             }
 
             unset($_SESSION['oauth']['state']);
-            $this->requestAccessToken('GET', array(), 'json');
+            $this->requestAccessToken('POST', array(), 'json');
 
             return true;
         }
@@ -500,7 +500,7 @@ class OAuth extends ApiAuth implements AuthInterface
      * @return bool
      * @throws IncorrectParametersReturnedException
      */
-    protected function requestAccessToken($method = 'GET', array $params = array(), $responseType = 'flat')
+    protected function requestAccessToken($method = 'POST', array $params = array(), $responseType = 'flat')
     {
         $this->log('requestAccessToken()');
 
@@ -623,7 +623,7 @@ class OAuth extends ApiAuth implements AuthInterface
 
         } else {
             //OAuth 2.0
-            $authUrl .= '?client_id='.$this->_client_id.'&redirect_uri='.$this->_callback;
+            $authUrl .= '?client_id='.$this->_client_id.'&redirect_uri='.urlencode($this->_callback);
             $state                      = md5(time().mt_rand());
             $_SESSION['oauth']['state'] = $state;
             if ($this->_debug) {


### PR DESCRIPTION
**Background**
Mautic has a PR that allows the admin to configure a consumer without restricting to a specific callback URL. In this scenario, the oauth server needs to know what URL to return to post authorization. The library didn't include the callback when requesting the token and thus Mautic didn't redirect back to the requesting script. 

**Testing**
This is in partnership with PR https://github.com/mautic/mautic/pull/358. Create an oauth1a consumer without restricting a callback. Then try to authorize via the api tester. Before the PR, the server would just download a file with the token and not redirect. After the PR, the user should be redirected back to the api tester or whatever is included as the callback.  If a callback is configured in the Consumer, using a different callback will result in access denied.