### PR TITLE
Create non-static factory methods

### DIFF
--- a/lib/Auth/ApiAuth.php
+++ b/lib/Auth/ApiAuth.php
@@ -14,14 +14,32 @@ namespace Mautic\Auth;
  */
 class ApiAuth
 {
-
     /**
+     * Get an API Auth object
+     *
      * @param array  $parameters
      * @param string $authMethod
      *
-     * @return mixed
+     * @return $this
+     *
+     * @deprecated
      */
     public static function initiate($parameters = array(), $authMethod = 'OAuth')
+    {
+        $object = new self;
+
+        return $object->newAuth($parameters, $authMethod);
+    }
+
+    /**
+     * Get an API Auth object
+     *
+     * @param array  $parameters
+     * @param string $authMethod
+     *
+     * @return $this
+     */
+    public function newAuth($parameters = array(), $authMethod = 'OAuth')
     {
         $class      = 'Mautic\\Auth\\'.$authMethod;
         $authObject = new $class();

--- a/lib/MauticApi.php
+++ b/lib/MauticApi.php
@@ -12,6 +12,9 @@ namespace Mautic;
 use Mautic\Auth\AuthInterface;
 use Mautic\Exception\ContextNotFoundException;
 
+/**
+ * Mautic API Factory
+ */
 class MauticApi
 {
     /**
@@ -23,6 +26,8 @@ class MauticApi
      *
      * @return Api\Api
      * @throws ContextNotFoundException
+     *
+     * @deprecated
      */
     public static function getContext($apiContext, AuthInterface $auth, $baseUrl = '')
     {
@@ -41,5 +46,28 @@ class MauticApi
         }
 
         return $contexts[$apiContext];
+    }
+
+    /**
+     * Get an API context object
+     *
+     * @param string        $apiContext API context (leads, forms, etc)
+     * @param AuthInterface $auth       API Auth object
+     * @param string        $baseUrl    Base URL for API endpoints
+     *
+     * @return Api\Api
+     * @throws ContextNotFoundException
+     */
+    public function newApi($apiContext, AuthInterface $auth, $baseUrl = '')
+    {
+        $apiContext = ucfirst($apiContext);
+
+        $class = 'Mautic\\Api\\'.$apiContext;
+
+        if (!class_exists($class)) {
+            throw new ContextNotFoundException("A context of '$apiContext' was not found.");
+        }
+
+        return new $class($auth, $baseUrl);
     }
 }


### PR DESCRIPTION
This PR creates two new factory methods to replace the existing static methods in the `ApiAuth` and `MauticApi` classes.  With the current structure, these factory methods cannot be mocked in unit testing since PHPUnit cannot mock a static method.

In the `ApiAuth` class, the old `initiate` method is proxied directly to the new `newAuth` method.  In the `MauticApi` class, the new `newApi` method is mostly a carbon copy of the `getContext` method except without the static object cache; best practices for a factory method are that it should always return a new object and not have internal storage too.

Both static methods are flagged as deprecated and may be removed at a later date.