### PR TITLE
Log the API response at a debug level

### DIFF
--- a/lib/Api/Api.php
+++ b/lib/Api/Api.php
@@ -145,6 +145,8 @@ class Api implements LoggerAwareInterface
         try {
             $response = $this->auth->makeRequest($url, $parameters, $method);
 
+            $this->getLogger()->debug('API Response', array('response' => $response));
+
             if (!is_array($response)) {
                 $this->getLogger()->warning($response);
 


### PR DESCRIPTION
This adds support for logging the response object returned from the auth object's `makeRequest` at a debug level.