### PR TITLE
fix sample code error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ $callback  = '';
 // ApiAuth::initiate will accept an array of OAuth settings
 $settings = array(
     'baseUrl'          => '',       // Base URL of the Mautic instance
-    'version'          => 'OAuth2'  // Version of the OAuth can be OAuth2 or OAuth1a. OAuth2 is the default value.
+    'version'          => 'OAuth2', // Version of the OAuth can be OAuth2 or OAuth1a. OAuth2 is the default value.
     'clientKey'        => '',       // Client/Consumer key from Mautic
     'clientSecret'     => '',       // Client/Consumer secret key from Mautic
     'callback'         => ''        // Redirect URI/Callback URI for this script


### PR DESCRIPTION
Authorization's sample code does not working.
Because it losted ','.

```
PHP Parse error:  syntax error, unexpected ''clientKey'' (T_CONSTANT_ENCAPSED_STRING), expecting ')' 
```