### PR TITLE
add leads/{id}/delete URL template into API-tester

### DIFF
--- a/apitester/endpoints/Leads.json
+++ b/apitester/endpoints/Leads.json
@@ -5,6 +5,7 @@
     "leads/list/owners",
     "leads/new",
     "leads/edit/{id}",
+    "leads/{id}/delete",
     "leads/{id}/notes",
     "leads/{id}/lists",
     "leads/{id}/campaigns"


### PR DESCRIPTION
There's no template for the leads delete action in API-tester and documentation seems to have the URL wrong - please see https://github.com/mautic/developer-documentation/issues/11 .

This pull request adds the template for leads delete URL into API-tester.