### PR TITLE
use substr instead of strpos to match url ends with /

### DIFF
--- a/lib/Api/Api.php
+++ b/lib/Api/Api.php
@@ -91,7 +91,7 @@ class Api implements LoggerAwareInterface
      */
     public function setBaseUrl($url)
     {
-        if (strpos($url, -1) != '/') {
+        if(substr($url, -1) != '/') {
             $url .= '/';
         }
         


### PR DESCRIPTION
Even if the base url ends with a '/' , the setBaseUrl function was adding another '/' at the end of the Url. 

Because of this if api url was already set to _https://your_mauti_url/api/_, will end up as _https://your_mautic_url/api//_. 

Then in the second part of the function it checks if the url ends with 'api/' also fails because of the extra '/' added. This results in an api url like _https://your_mautic_url/api//api/_ which breaks all the api calls. 
