### PR TITLE
Search commands

### DIFF
--- a/lib/Api/Api.php
+++ b/lib/Api/Api.php
@@ -120,7 +120,7 @@ class Api implements LoggerAwareInterface
      *
      * @return boolean
      */
-    public function hasCommand($command)
+    public function hasSearchCommand($command)
     {
         return in_array($command, $this->searchCommands);
     }

--- a/lib/Api/Api.php
+++ b/lib/Api/Api.php
@@ -48,6 +48,13 @@ class Api implements LoggerAwareInterface
     protected $baseUrl;
 
     /**
+     * Array of available search commands
+     *
+     * @var array
+     */
+    protected $searchCommands = [];
+
+    /**
      * @var AuthInterface
      */
     private $auth;
@@ -94,6 +101,28 @@ class Api implements LoggerAwareInterface
         $this->logger = $logger;
 
         return $this;
+    }
+
+    /**
+     * Get the array of available search commands
+     *
+     * @return array
+     */
+    public function getSearchCommands()
+    {
+        return $this->searchCommands;
+    }
+
+    /**
+     * Check if the search command is available
+     *
+     * @param string $command
+     *
+     * @return boolean
+     */
+    public function hasCommand($command)
+    {
+        return in_array($command, $this->searchCommands);
     }
 
     /**

--- a/lib/Api/Assets.php
+++ b/lib/Api/Assets.php
@@ -29,4 +29,16 @@ class Assets extends Api
      * {@inheritdoc}
      */
     protected $itemName = 'asset';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+        'is:published',
+        'is:unpublished',
+        'is:mine',
+        'is:uncategorized',
+        'category',
+    ];
 }

--- a/lib/Api/Campaigns.php
+++ b/lib/Api/Campaigns.php
@@ -31,6 +31,18 @@ class Campaigns extends Api
     protected $itemName = 'campaign';
 
     /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+        'is:published',
+        'is:unpublished',
+        'is:mine',
+        'is:uncategorized',
+        'category',
+    ];
+
+    /**
      * Add a lead to the campaign
      *
      * @deprecated 2.0.1, use addContact instead

--- a/lib/Api/Categories.php
+++ b/lib/Api/Categories.php
@@ -29,4 +29,13 @@ class Categories extends Api
      * {@inheritdoc}
      */
     protected $itemName = 'category';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+        'is:published',
+        'is:unpublished',
+    ];
 }

--- a/lib/Api/Companies.php
+++ b/lib/Api/Companies.php
@@ -31,6 +31,14 @@ class Companies extends Api
     protected $itemName = 'company';
 
     /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+        'is:mine',
+    ];
+
+    /**
      * Add a contact to the company
      *
      * @param int $id        Company ID

--- a/lib/Api/Contacts.php
+++ b/lib/Api/Contacts.php
@@ -46,6 +46,23 @@ class Contacts extends Api
     protected $itemName = 'contact';
 
     /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+        'is:anonymous',
+        'is:unowned',
+        'is:mine',
+        'name',
+        'email',
+        'segment',
+        'company',
+        'onwer',
+        'ip',
+        'common',
+    ];
+
+    /**
      * Get a list of users available as contact owners
      *
      * @return array|mixed

--- a/lib/Api/DynamicContents.php
+++ b/lib/Api/DynamicContents.php
@@ -28,4 +28,17 @@ class DynamicContents extends Api
      * {@inheritdoc}
      */
     protected $itemName = 'dynamicContent';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+        'is:published',
+        'is:unpublished',
+        'is:mine',
+        'is:uncategorized',
+        'category',
+        'lang',
+    ];
 }

--- a/lib/Api/Emails.php
+++ b/lib/Api/Emails.php
@@ -30,6 +30,19 @@ class Emails extends Api
      */
     protected $itemName = 'email';
 
+    /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+        'is:published',
+        'is:unpublished',
+        'is:mine',
+        'is:uncategorized',
+        'category',
+        'lang',
+    ];
+
 
     /**
      * Send email to the assigned lists

--- a/lib/Api/Forms.php
+++ b/lib/Api/Forms.php
@@ -31,6 +31,20 @@ class Forms extends Api
     protected $itemName = 'form';
 
     /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+        'is:published',
+        'is:unpublished',
+        'is:mine',
+        'is:uncategorized',
+        'category',
+        'name',
+        'has:results',
+    ];
+
+    /**
      * Remove fields from a form
      *
      * @param integer $formId

--- a/lib/Api/Notes.php
+++ b/lib/Api/Notes.php
@@ -14,7 +14,6 @@ namespace Mautic\Api;
  */
 class Notes extends Api
 {
-
     /**
      * {@inheritdoc}
      */
@@ -29,4 +28,11 @@ class Notes extends Api
      * {@inheritdoc}
      */
     protected $itemName = 'note';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+    ];
 }

--- a/lib/Api/Notifications.php
+++ b/lib/Api/Notifications.php
@@ -29,4 +29,17 @@ class Notifications extends Api
      * {@inheritdoc}
      */
     protected $itemName = 'notification';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+        'is:published',
+        'is:unpublished',
+        'is:mine',
+        'is:uncategorized',
+        'category',
+        'lang',
+    ];
 }

--- a/lib/Api/Pages.php
+++ b/lib/Api/Pages.php
@@ -29,4 +29,17 @@ class Pages extends Api
      * {@inheritdoc}
      */
     protected $itemName = 'page';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+        'is:published',
+        'is:unpublished',
+        'is:mine',
+        'is:uncategorized',
+        'category',
+        'lang',
+    ];
 }

--- a/lib/Api/PointTriggers.php
+++ b/lib/Api/PointTriggers.php
@@ -31,6 +31,13 @@ class PointTriggers extends Api
     protected $itemName = 'trigger';
 
     /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+    ];
+
+    /**
      * Remove events from a point trigger
      *
      * @param integer $triggerId

--- a/lib/Api/Points.php
+++ b/lib/Api/Points.php
@@ -31,6 +31,13 @@ class Points extends Api
     protected $itemName = 'point';
 
     /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+    ];
+
+    /**
      * Get list of available action types
      *
      * @return array|mixed

--- a/lib/Api/Reports.php
+++ b/lib/Api/Reports.php
@@ -33,6 +33,16 @@ class Reports extends Api
     /**
      * {@inheritdoc}
      */
+    protected $searchCommands = [
+        'ids',
+        'is:published',
+        'is:unpublished',
+        'is:mine',
+    ];
+
+    /**
+     * {@inheritdoc}
+     */
     public function create(array $parameters)
     {
         return $this->actionNotSupported('create');

--- a/lib/Api/Roles.php
+++ b/lib/Api/Roles.php
@@ -29,4 +29,13 @@ class Roles extends Api
      * {@inheritdoc}
      */
     protected $itemName = 'role';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+        'is:admin',
+        'name',
+    ];
 }

--- a/lib/Api/Smses.php
+++ b/lib/Api/Smses.php
@@ -29,4 +29,17 @@ class Smses extends Api
      * {@inheritdoc}
      */
     protected $itemName = 'sms';
+
+    /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+        'is:published',
+        'is:unpublished',
+        'is:mine',
+        'is:uncategorized',
+        'category',
+        'lang',
+    ];
 }

--- a/lib/Api/Stages.php
+++ b/lib/Api/Stages.php
@@ -31,6 +31,13 @@ class Stages extends Api
     protected $itemName = 'stage';
 
     /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+    ];
+
+    /**
      * Add a contact to the stage
      *
      * @param int $id        Stage ID

--- a/lib/Api/Users.php
+++ b/lib/Api/Users.php
@@ -31,6 +31,21 @@ class Users extends Api
     protected $itemName = 'user';
 
     /**
+     * {@inheritdoc}
+     */
+    protected $searchCommands = [
+        'ids',
+        'is:admin',
+        'is:active',
+        'is:inactive',
+        'email',
+        'role',
+        'username',
+        'name',
+        'position',
+    ];
+
+    /**
      * Get your (API) user
      *
      * @return array|mixed

--- a/tests/Api/ExceptionsTest.php
+++ b/tests/Api/ExceptionsTest.php
@@ -98,4 +98,9 @@ class ExceptionsTest extends MauticApiTestCase
         $this->assertEquals(self::CUSTOM_ERROR_MESSAGE, $exception->getMessage(), 'This should return "'.self::CUSTOM_ERROR_MESSAGE.'"' );
         $this->assertEquals(500, $exception->getCode());
     }
+
+    public function testSearchCommands() {
+        // overwrite this inheritted method with no content
+    }
+
 }

--- a/tests/Api/MauticApiTestCase.php
+++ b/tests/Api/MauticApiTestCase.php
@@ -138,4 +138,14 @@ abstract class MauticApiTestCase extends \PHPUnit_Framework_TestCase
         $response = $this->api->delete($response[$this->api->itemName()]['id']);
         $this->assertErrors($response);
     }
+
+    public function testSearchCommands() {
+        $commands = $this->api->getSearchCommands();
+
+        foreach ($commands as $command) {
+            $this->assertTrue($this->api->hasSearchCommand($command));
+        }
+
+        $this->assertFalse($this->api->hasSearchCommand('this:command:should:not:exist'));
+    }
 }


### PR DESCRIPTION
It can be useful to ask a API endpoint whether it supports some search command we'd like to use. One particular use case can be if we can get several items by IDs in one request or one by one; if we can use the `ids:ID1,ID2,IDn` command. Now it's possible to do something like this:
```
$ids = [243,342,34];

if ($api->hasSearchCommand('ids')) {
    // Use only one API call to get all the items
    $items = $api->getList('ids:'.implode(',', $ids))[$api->listName()];
} else {
    // If the search command is not available, fetch them one by one
    $items = [];
    foreach ($ids as $id) {
        $items[] = $api->get($id)[$api->itemName()];
    }
}
```

Test with `$ phpunit --filter testSearchCommands`
