### PR TITLE
ApiAuth::newAuth() returns a new ApiInterface

### DIFF
--- a/lib/Auth/ApiAuth.php
+++ b/lib/Auth/ApiAuth.php
@@ -37,7 +37,7 @@ class ApiAuth
      * @param array  $parameters
      * @param string $authMethod
      *
-     * @return $this
+     * @return AuthInterface
      */
     public function newAuth($parameters = array(), $authMethod = 'OAuth')
     {


### PR DESCRIPTION
Use the correct phpDoc `@return` statement. This is the type which is expected by the `\Mautic\MauticApi::newApi()`