### PR TITLE
Fixing marketing message channels test assertion after channelName was added

### DIFF
--- a/tests/Api/MessagesTest.php
+++ b/tests/Api/MessagesTest.php
@@ -76,7 +76,7 @@ class MessagesTest extends MauticApiTestCase
             foreach ($response[$this->api->itemName()]['channels'] as $responseChannel) {
                 // All channels will be returned, even the empty ones
                 if (isset($this->testPayload['channels'][$responseChannel['channel']])) {
-                    unset($responseChannel['id']);
+                    unset($responseChannel['id'], $responseChannel['channelName']);
                     $this->assertSame($this->testPayload['channels'][$responseChannel['channel']], $responseChannel);
                 }
             }


### PR DESCRIPTION
When the channelName param was added to the marketing message response, it broke the tests. This PR unsets the channelName before it's sent to create/edit MM.