### PR TITLE
Fix: Onwer typo in lib/Api/Contacts.php

### DIFF
--- a/lib/Api/Contacts.php
+++ b/lib/Api/Contacts.php
@@ -65,7 +65,7 @@ class Contacts extends Api
         'email',
         'segment',
         'company',
-        'onwer',
+        'owner',
         'ip',
         'common',
     );


### PR DESCRIPTION
Simply fixes the Owner typo in the Contacts API class