### PR TITLE
Contact tests fixed after contacts with the same email are being merged into one

### DIFF
--- a/tests/Api/ContactsTest.php
+++ b/tests/Api/ContactsTest.php
@@ -62,9 +62,31 @@ class ContactsTest extends AbstractCustomFieldsTest
         $this->standardTestGetList();
     }
 
+    /**
+     * We cannot use standard method since contacts with the same email are merged into one
+     */
     public function testGetListOfSpecificIds()
     {
-        $this->standardTestGetListOfSpecificIds();
+        // Create some items first
+        $itemIds = array();
+        for ($i = 0; $i <= 2; $i++) {
+            $testPayload = $this->testPayload;
+            $testPayload['email'] = $i.$this->testPayload['email'];
+            $response = $this->api->create($testPayload);
+            $this->assertErrors($response);
+            $itemIds[] = $response[$this->api->itemName()]['id'];
+        }
+
+        $search   = 'ids:'.implode(',', $itemIds);
+        $response = $this->api->getList($search);
+        $this->assertErrors($response);
+        $this->assertEquals(count($itemIds), $response['total']);
+
+        foreach ($response[$this->api->listName()] as $item) {
+            $this->assertTrue(in_array($item['id'], $itemIds));
+            $this->api->delete($item['id']);
+            $this->assertErrors($response);
+        }
     }
 
     public function testGetListOfSpecificSegment()
@@ -84,8 +106,11 @@ class ContactsTest extends AbstractCustomFieldsTest
         $itemIds = array();
         for ($i = 0; $i <= 2; $i++) {
 
+            $testPayload = $this->testPayload;
+            $testPayload['email'] = $i.$this->testPayload['email'];
+
             // Create some items
-            $response = $this->api->create($this->testPayload);
+            $response = $this->api->create($testPayload);
             $this->assertErrors($response);
             $itemIds[] = $response[$this->api->itemName()]['id'];
 

--- a/tests/Api/LeadsTest.php
+++ b/tests/Api/LeadsTest.php
@@ -13,16 +13,8 @@ class LeadsTest extends ContactsTest
 {
     public function setUp()
     {
+        parent::setUp();
         $this->api = $this->getContext('leads');
-        $this->testPayload = array(
-            'firstname' => 'test',
-            'lastname'  => 'test',
-            'points'    => 3,
-            'tags'      => array(
-                'APItag1',
-                'APItag2',
-            )
-        );
     }
 
     // Use the method from ContactsTest to test the 'leads' endpoint for BC


### PR DESCRIPTION
Fixing phpunit tests for Mautic 2.8.0 together with https://github.com/mautic/mautic/pull/3881

How to test:
Apply https://github.com/mautic/mautic/pull/3881 on your Mautic, then apply this PR and run `phpunit` in the api-library directory.