### PR TITLE
Add method to set temporary filepath in theme API

### DIFF
--- a/lib/Api/Api.php
+++ b/lib/Api/Api.php
@@ -254,7 +254,11 @@ class Api implements LoggerAwareInterface
                 );
             } else {
                 try {
-                    $response = $this->auth->makeRequest($url, $parameters, $method);
+                    $settings = [];
+                    if (method_exists($this, 'getTemporaryFilePath')) {
+                        $settings['temporaryFilePath'] = $this->getTemporaryFilePath();
+                    }
+                    $response = $this->auth->makeRequest($url, $parameters, $method, $settings);
 
                     $this->getLogger()->debug('API Response', array('response' => $response));
 

--- a/lib/Api/Themes.php
+++ b/lib/Api/Themes.php
@@ -90,7 +90,7 @@ class Themes extends Api
     /**
      * @param null $temporaryFilePath
      */
-    public function setTemporaryFileath($temporaryFilePath)
+    public function setTemporaryFilePath($temporaryFilePath)
     {
         $temporaryFilePath = realpath($temporaryFilePath);
         $this->temporaryFilePath = $temporaryFilePath;

--- a/lib/Api/Themes.php
+++ b/lib/Api/Themes.php
@@ -92,7 +92,6 @@ class Themes extends Api
      */
     public function setTemporaryFilePath($temporaryFilePath)
     {
-        $temporaryFilePath = realpath($temporaryFilePath);
         $this->temporaryFilePath = $temporaryFilePath;
     }
 }

--- a/lib/Api/Themes.php
+++ b/lib/Api/Themes.php
@@ -30,6 +30,9 @@ class Themes extends Api
      */
     protected $itemName = 'theme';
 
+    protected $temporaryFilePath = null;
+
+
     /**
      * {@inheritdoc}
      */
@@ -74,5 +77,22 @@ class Themes extends Api
     public function deleteBatch(array $ids)
     {
         return $this->actionNotSupported('deleteBatch');
+    }
+
+    /**
+     * @return null
+     */
+    public function getTemporaryFilepath()
+    {
+        return $this->temporaryFilePath ?: sys_get_temp_dir();
+    }
+
+    /**
+     * @param null $temporaryFilePath
+     */
+    public function setTemporaryFileath($temporaryFilePath)
+    {
+        $temporaryFilePath = realpath($temporaryFilePath);
+        $this->temporaryFilePath = $temporaryFilePath;
     }
 }

--- a/lib/Auth/AbstractAuth.php
+++ b/lib/Auth/AbstractAuth.php
@@ -195,6 +195,11 @@ abstract class AbstractAuth implements AuthInterface
         // Handle zip file response
         if (!empty($this->_httpResponseInfo['content_type']) && $this->_httpResponseInfo['content_type'] === 'application/zip') {
             $temporaryFilePath = isset($settings['temporaryFilePath']) ? $settings['temporaryFilePath'] : sys_get_temp_dir();
+            if (!file_exists($temporaryFilePath)){
+                if (!@mkdir($temporaryFilePath) && !is_dir($temporaryFilePath)) {
+                    throw new \Exception('Cannot create directory ' . $temporaryFilePath);
+                };
+            }
             $file = tempnam($temporaryFilePath, 'mautic_api_');
 
             if (!is_writable($file)) {

--- a/lib/Auth/AbstractAuth.php
+++ b/lib/Auth/AbstractAuth.php
@@ -194,7 +194,8 @@ abstract class AbstractAuth implements AuthInterface
 
         // Handle zip file response
         if (!empty($this->_httpResponseInfo['content_type']) && $this->_httpResponseInfo['content_type'] === 'application/zip') {
-            $file = tempnam(sys_get_temp_dir(), 'mautic_api_');
+            $temporaryFilePath = isset($settings['temporaryFilePath']) ? $settings['temporaryFilePath'] : sys_get_temp_dir();
+            $file = tempnam($temporaryFilePath, 'mautic_api_');
 
             if (!is_writable($file)) {
                 throw new \Exception($file.' is not writable');

--- a/tests/Api/ThemesTest.php
+++ b/tests/Api/ThemesTest.php
@@ -39,7 +39,9 @@ class ThemesTest extends MauticApiTestCase
 
         // Test setTemporaryFilePath
         $dir = getenv('HOME') . DIRECTORY_SEPARATOR . 'mytempdir';
-        mkdir($dir);
+        if (!file_exists($dir)) {
+            mkdir($dir);
+        }
         $this->api->setTemporaryFilePath($dir);
         $response = $this->api->get('blank');
         $this->assertErrors($response);

--- a/tests/Api/ThemesTest.php
+++ b/tests/Api/ThemesTest.php
@@ -37,6 +37,16 @@ class ThemesTest extends MauticApiTestCase
         $this->assertFalse(empty($response['file']));
         $this->assertTrue(file_exists($response['file']));
 
+        // Test setTemporaryFilePath
+        $dir = getenv('HOME') . DIRECTORY_SEPARATOR . 'mytempdir';
+        mkdir($dir);
+        $this->api->setTemporaryFilePath($dir);
+        $response = $this->api->get('blank');
+        $this->assertErrors($response);
+        $this->assertFalse(empty($response['file']));
+        $this->assertTrue(file_exists($response['file']));
+        $this->assertEquals($dir, dirname($response['file']));
+
         // Create a new theme from the theme we just got
         $tmpFile = dirname(__DIR__).'/'.$themeName.'.zip';
         $this->assertTrue(rename($response['file'], $tmpFile), 'could not create '.$tmpFile);

--- a/tests/Api/ThemesTest.php
+++ b/tests/Api/ThemesTest.php
@@ -38,7 +38,7 @@ class ThemesTest extends MauticApiTestCase
         $this->assertTrue(file_exists($response['file']));
 
         // Test setTemporaryFilePath
-        $dir = getenv('HOME') . DIRECTORY_SEPARATOR . 'mytempdir';
+        $dir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'mytempdir';
         $this->api->setTemporaryFilePath($dir);
         $response = $this->api->get('blank');
         $this->assertErrors($response);

--- a/tests/Api/ThemesTest.php
+++ b/tests/Api/ThemesTest.php
@@ -39,9 +39,6 @@ class ThemesTest extends MauticApiTestCase
 
         // Test setTemporaryFilePath
         $dir = getenv('HOME') . DIRECTORY_SEPARATOR . 'mytempdir';
-        if (!file_exists($dir)) {
-            mkdir($dir);
-        }
         $this->api->setTemporaryFilePath($dir);
         $response = $this->api->get('blank');
         $this->assertErrors($response);


### PR DESCRIPTION
This will permit to set a different path than '/tmp' to distributed environments.

How to test:
Apply this PR and run `phpunit tests/Api/ThemesTest.php` in the api-library directory.