### PR TITLE
Better handling of bad responses, Response class started, tests added

### DIFF
--- a/lib/Exception/AbstractApiException.php
+++ b/lib/Exception/AbstractApiException.php
@@ -27,7 +27,7 @@ abstract class AbstractApiException extends \Exception
     {
         if (empty($message)) {
             // Use message appropriate to the subclass with late binding
-            $message = static::DEFAULT_MESSAGE;
+            $message = self::DEFAULT_MESSAGE;
         }
 
         parent::__construct($message, $code, $previous);

--- a/lib/Exception/UnexpectedResponseFormatException.php
+++ b/lib/Exception/UnexpectedResponseFormatException.php
@@ -9,6 +9,8 @@
 
 namespace Mautic\Exception;
 
+use Mautic\Response;
+
 /**
  * Exception representing an unexpected HTTP response
  */
@@ -18,4 +20,41 @@ class UnexpectedResponseFormatException extends AbstractApiException
      * {@inheritdoc}
      */
     const DEFAULT_MESSAGE = 'The response returned is in an unexpected format.';
+
+    /**
+     * @var Response
+     */
+    private $response;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(Response $response, $message = '', $code = 500, \Exception $previous = null)
+    {
+        $this->response = $response;
+
+        if (empty($message)) {
+            // Use message appropriate to the subclass with late binding
+            $message = static::DEFAULT_MESSAGE;
+        }
+
+        $message .= "\n\nResponse: ";
+
+        // Attach first 1000 characters of the body
+        if (mb_strlen($response->getBody()) > 1000) {
+            $message .= mb_substr($response->getBody(), 0, 1000).'...';
+        } else {
+            $message .= $response->getBody();
+        }
+
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @return Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
 }

--- a/lib/Exception/UnexpectedResponseFormatException.php
+++ b/lib/Exception/UnexpectedResponseFormatException.php
@@ -35,7 +35,7 @@ class UnexpectedResponseFormatException extends AbstractApiException
 
         if (empty($message)) {
             // Use message appropriate to the subclass with late binding
-            $message = static::DEFAULT_MESSAGE;
+            $message = self::DEFAULT_MESSAGE;
         }
 
         $message .= "\n\nResponse: ";

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -56,7 +56,6 @@ class Response
             $parsed = $this->decodeFromJson();
         } catch (UnexpectedResponseFormatException $e) {
             $parsed = $this->decodeFromUrlParams();
-            die(var_dump($parsed));
         }
 
         return $parsed;
@@ -124,6 +123,7 @@ class Response
      * @param string $path
      *
      * @return array
+     * @throws \Exception
      */
     public function saveToFile($path)
     {

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2014 Mautic, NP. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     MIT http://opensource.org/licenses/MIT
+ */
+
+namespace Mautic;
+
+use Mautic\Exception\UnexpectedResponseFormatException;
+
+/**
+ * Class helping with API responses
+ */
+class Response
+{
+    private $headers;
+    private $body;
+    private $info;
+
+    /**
+     * @param string $response
+     * @param array  $info
+     */
+    public function __construct($response, array $info)
+    {
+        $this->info = $info;
+        $this->parseResponse($response);
+        $this->validate();
+    }
+
+    /**
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * @return string
+     */
+    public function getBody()
+    {
+        return $this->body;
+    }
+
+    /**
+     * @return array
+     */
+    public function getDecodedBody()
+    {
+        try {
+            $parsed = $this->decodeFromJson();
+        } catch (UnexpectedResponseFormatException $e) {
+            $parsed = $this->decodeFromUrlParams();
+            die(var_dump($parsed));
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * @return array
+     *
+     * @throws UnexpectedResponseFormatException
+     */
+    public function decodeFromJson()
+    {
+        $parsed = json_decode($this->body, true);
+
+        if (is_null($parsed)) {
+            throw new UnexpectedResponseFormatException($this);
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * @return array
+     *
+     * @throws UnexpectedResponseFormatException
+     */
+    public function decodeFromUrlParams()
+    {
+        if (strpos($this->body, '=') !== false) {
+            parse_str($this->body, $parsed);
+        }
+
+        if (empty($parsed)) {
+            throw new UnexpectedResponseFormatException($this);
+        }
+
+        return $parsed;
+    }
+
+    /**
+     * @return array
+     */
+    public function getInfo()
+    {
+        return $this->info;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isZip()
+    {
+        return !empty($this->info['content_type']) && $this->info['content_type'] === 'application/zip';
+    }
+
+    /**
+     * @return bool
+     */
+    public function isHtml()
+    {
+        return substr($this->body, 0, 1) === '<';
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return array
+     */
+    public function saveToFile($path)
+    {
+        if (!file_exists($path)) {
+            if (!@mkdir($path) && !is_dir($path)) {
+                throw new \Exception('Cannot create directory ' . $path);
+            };
+        }
+        $file = tempnam($path, 'mautic_api_');
+
+        if (!is_writable($file)) {
+            throw new \Exception($file.' is not writable');
+        }
+
+        if (!$handle = fopen($file, 'w')) {
+            throw new \Exception('Cannot open file '.$file);
+        }
+
+        if (fwrite($handle, $this->body) === false) {
+            throw new \Exception('Cannot write into file '.$file);
+        }
+
+        fclose($handle);
+
+        return array(
+            'file' => $file,
+        );
+    }
+
+    /**
+     * @param string $response
+     */
+    private function parseResponse($response)
+    {
+        $exploded = explode("\r\n\r\n", $response);
+        $this->body = trim(array_pop($exploded));
+        $this->headers = implode("\r\n\r\n", $exploded);
+    }
+
+    /**
+     * @throws UnexpectedResponseFormatException
+     */
+    private function validate()
+    {
+        if (!in_array($this->info['http_code'], array(200, 201))) {
+            $message = 'The response has unexpected status code ('.$this->info['http_code'].').';
+            throw new UnexpectedResponseFormatException($this, $message);
+        }
+
+        if ($this->isHtml()) {
+            throw new UnexpectedResponseFormatException($this);
+        }
+    }
+}

--- a/tests/Api/Auth/AbstractAuthTest.php
+++ b/tests/Api/Auth/AbstractAuthTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2014 Mautic, NP. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     MIT http://opensource.org/licenses/MIT
+ */
+
+namespace Mautic\Tests\Api\Auth;
+
+use Mautic\Auth\AbstractAuth;
+use Mautic\Exception\UnexpectedResponseFormatException;
+
+class AbstractAuthTest extends \PHPUnit_Framework_TestCase
+{
+    protected $config;
+
+    public function setUp()
+    {
+        $this->config = include __DIR__.'/../../local.config.php';
+    }
+
+    public function test404Response()
+    {
+        $auth = $this->getMockForAbstractClass(AbstractAuth::class);
+        $this->expectException(UnexpectedResponseFormatException::class);
+        $auth->makeRequest('https://github.com/mautic/api-library/this-page-does-not-exist');
+    }
+
+    public function testHtmlResponse()
+    {
+        $auth = $this->getMockForAbstractClass(AbstractAuth::class);
+        $this->expectException(UnexpectedResponseFormatException::class);
+        $auth->makeRequest($this->config['baseUrl']);
+    }
+
+    public function testJsonResponse()
+    {
+        $auth = $this->getMockForAbstractClass(AbstractAuth::class);
+        $response = $auth->makeRequest($this->config['apiUrl'].'contacts');
+        $this->assertTrue(is_array($response));
+        $this->assertFalse(empty($response));
+    }
+}

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2014 Mautic, NP. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     MIT http://opensource.org/licenses/MIT
+ */
+
+namespace Mautic\Tests;
+
+use Mautic\Response;
+use Mautic\Exception\UnexpectedResponseFormatException;
+
+class ResponseTest extends \PHPUnit_Framework_TestCase
+{
+    private $headersWithRedirects = 'HTTP/1.1 302 Found
+Date: Fri, 17 Nov 2017 14:09:31 GMT
+Server: Apache/2.4.25 (Unix) OpenSSL/0.9.8zh PHP/7.0.15
+X-Powered-By: PHP/7.0.15
+Set-Cookie: 9743595cf0a472cb3ec0272949ffe7e8=4ocah9itj45lmnhv4ub25ml1b7; path=/; HttpOnly
+Cache-Control: no-cache
+Location: /index_dev.php/s/dashboard
+Content-Length: 348
+
+Content-Type: text/html; charset=UTF-8
+
+HTTP/1.1 302 Found
+Date: Fri, 17 Nov 2017 14:09:31 GMT
+Server: Apache/2.4.25 (Unix) OpenSSL/0.9.8zh PHP/7.0.15
+X-Powered-By: PHP/7.0.15
+Set-Cookie: 9743595cf0a472cb3ec0272949ffe7e8=ahtmrsuem98b5kunm2g162pa85; path=/; HttpOnly
+Cache-Control: no-cache
+Location: http://mautic.dev/index_dev.php/s/login
+Content-Length: 400
+Content-Type: text/html; charset=UTF-8
+
+HTTP/1.1 200 OK
+Date: Fri, 17 Nov 2017 14:09:31 GMT
+Server: Apache/2.4.25 (Unix) OpenSSL/0.9.8zh PHP/7.0.15
+X-Powered-By: PHP/7.0.15
+Set-Cookie: 9743595cf0a472cb3ec0272949ffe7e8=psh2rh9cam538t1u3e1gd3d8l3; path=/; HttpOnly
+Cache-Control: no-cache
+Transfer-Encoding: chunked
+Content-Type: text/html; charset=UTF-8';
+
+    private $space = "\r\n\r\n";
+
+    private $htmlBody = '<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8" />
+</head>
+<body>
+    hello world
+</body>
+</html>';
+
+    private $jsonBody = '{
+        "hello": "world"
+    }';
+
+    private $urlParamBody = 'first=value&arr[]=foo+bar&arr[]=baz';
+
+    private $curlInfo = array(
+        'url' => 'http://mautic.dev/index_dev.php',
+        'content_type' => null,
+        'http_code' => 200,
+        'header_size' => 0,
+        'request_size' => 0,
+        'filetime' => -1,
+        'ssl_verify_result' => 0,
+        'redirect_count' => 0,
+        'total_time' => 0,
+        'namelookup_time' => 0,
+        'connect_time' => 0,
+        'pretransfer_time' => 0,
+        'size_upload' => 0,
+        'size_download' => 0,
+        'speed_download' => 0,
+        'speed_upload' => 0,
+        'download_content_length' => -1,
+        'upload_content_length' => -1,
+        'starttransfer_time' => 0,
+        'redirect_time' => 0,
+        'redirect_url' => null,
+        'primary_ip' => null,
+        'certinfo' => array(),
+        'primary_port' => 0,
+        'local_ip' => null,
+        'local_port' => 0,
+    );
+
+    private function getHtmlResponse()
+    {
+        return $this->headersWithRedirects.$this->space.$this->htmlBody;
+    }
+
+    private function getJsonResponse()
+    {
+        return $this->headersWithRedirects.$this->space.$this->jsonBody;
+    }
+
+    private function getUrlParamResponse()
+    {
+        return $this->headersWithRedirects.$this->space.$this->urlParamBody;
+    }
+
+    private function getInfo($code = 200)
+    {
+        $info = $this->curlInfo;
+        $info['http_code'] = $code;
+        return $info;
+    }
+
+    public function testParseResponse()
+    {
+        $response = new Response($this->getHtmlResponse(), $this->getInfo());
+        $this->assertSame($this->headersWithRedirects, $response->getHeaders());
+        $this->assertSame($this->htmlBody, $response->getBody());
+        $this->assertSame($this->getInfo(), $response->getInfo());
+    }
+
+    public function testValidation()
+    {
+        $this->expectException(UnexpectedResponseFormatException::class);
+        $response = new Response($this->getHtmlResponse(), $this->getInfo(500));
+    }
+
+    public function testDecodeFromUrlParamsWithParams()
+    {
+        $response = new Response($this->getUrlParamResponse(), $this->getInfo());
+        $responseParams = $response->decodeFromUrlParams();
+        $this->assertSame('value', $responseParams['first']);
+    }
+
+    public function testDecodeFromUrlParamsWithNoParams()
+    {
+        $response = new Response($this->headersWithRedirects.$this->space, $this->getInfo());
+        $this->expectException(UnexpectedResponseFormatException::class);
+        $response->decodeFromUrlParams();
+    }
+
+    public function testDecodeFromJsonWithJson()
+    {
+        $response = new Response($this->getJsonResponse(), $this->getInfo());
+        $json = $response->decodeFromJson();
+        $this->assertSame('world', $json['hello']);
+    }
+
+    public function testDecodeFromJsonWithEmptyJson()
+    {
+        $response = new Response($this->headersWithRedirects.$this->space, $this->getInfo());
+        $this->expectException(UnexpectedResponseFormatException::class);
+        $response->decodeFromUrlParams();
+    }
+
+    public function testGetDecodedBodyWithJson()
+    {
+        $response = new Response($this->getJsonResponse(), $this->getInfo());
+        $body = $response->getDecodedBody();
+        $this->assertSame('world', $body['hello']);
+    }
+
+    public function testDecodeFromJsonWithEmptyResponse()
+    {
+        $response = new Response($this->headersWithRedirects.$this->space, $this->getInfo());
+        $body = $response->getDecodedBody();
+        $this->assertSame('', $body);
+    }
+
+    public function testDecodeFromJsonWithTextResponse()
+    {
+        $response = new Response($this->headersWithRedirects.$this->space.'OK', $this->getInfo());
+        $body = $response->getDecodedBody();
+        $this->assertSame('OK', $body);
+    }
+
+    public function testSaveToFile()
+    {
+        $response = new Response($this->getJsonResponse(), $this->getInfo());
+        $result = $response->saveToFile(sys_get_temp_dir());
+        $this->assertFalse(empty($result['file']));
+        $this->assertTrue(file_exists($result['file']));
+        $this->assertSame($this->jsonBody, file_get_contents($result['file']));
+        $this->assertTrue(unlink($result['file']));
+    }
+
+    public function testIsZip()
+    {
+        $response = new Response($this->getJsonResponse(), ['http_code' => 200, 'content_type' => 'application/zip']);
+        $this->assertTrue($response->isZip());
+    }
+
+    public function testIsNotZip()
+    {
+        $response = new Response($this->getJsonResponse(), ['http_code' => 200, 'content_type' => 'application/json']);
+        $this->assertFalse($response->isZip());
+    }
+}


### PR DESCRIPTION
This PR moves the HTML response responsibility from `AbstractAuth` to new `Response` class. It improves testability and the tests are part of this PR.

This PR also slightly changes the behavior. I don't consider it a BC break but bug fix.
- If the response is in bad format like HTML the `UnexpectedResponseFormatException` is thrown. This exception was previously thrown only if HTTP code was not 200 or 201.
- The `UnexpectedResponseFormatException` has first new param and that is the new Response class so it could build a more detailed error message out of it. That can be considered to be BC, but exceptions from this library should not be thrown in code outside of this library.