### PR TITLE
404 error handling and unit test fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ Mautic's API. If you intend on using Basic Authentication, ensure you enable it.
 then copy the Client ID and Client Secret to the application that will be using the API.
 
 ## Authorization
-    
+
 ### Obtaining an access token
 The first step is to obtain authorization.  Mautic supports OAuth 1.0a and OAuth 2 however it is up to the administrator
-to decide which is enabled.  Thus it is best to have a configuration option within your project for the administrator 
+to decide which is enabled.  Thus it is best to have a configuration option within your project for the administrator
 to choose what method should be used by your code.
 
 ```php
@@ -27,9 +27,9 @@ use Mautic\Auth\ApiAuth;
 
 session_start();
 
-$publicKey = ''; 
-$secretKey = ''; 
-$callback  = ''; 
+$publicKey = '';
+$secretKey = '';
+$callback  = '';
 
 // ApiAuth->newAuth() will accept an array of Auth settings
 $settings = array(
@@ -114,7 +114,7 @@ $auth = $initAuth->newAuth($settings, 'BasicAuth');
        'code'    => 403,
        'message' => 'access_denied: OAuth2 authentication required' )
  )
- 
+
 ```
 
 ## API Requests
@@ -169,12 +169,12 @@ foreach ($fields as $field) {
 
 // Set the IP address the contact originated from if it is different than that of the server making the request
 $data['ipAddress'] = $ipAddress;
- 
-// Create the contact 
+
+// Create the contact
 $response = $contactApi->create($data);
 $contact = $response[$contactApi->itemName()];
 ```
-    
+
 ### Editing an item
 Currently, only Contacts support this
 
@@ -193,7 +193,7 @@ $contact = $response[$contactApi->itemName()];
 $response = $contactApi->edit($contactId, $updatedData, true);
 $contact = $response[$contactApi->itemName()];
 ```
-    
+
 ### Deleting an item
 
 ```php
@@ -228,8 +228,8 @@ Configure the unit tests config before running the unit tests. The tests fire re
 4. Click Submit to store the URL to the session.
 5. Fill in one of the OAuth credentials and authorize.
 6. Open the $_SESSION array and copy the 'access_token' to the local.config.php file.
-7. Then run `phpunit` to run the tests.
+7. Then run `vendor/bin/phpunit` to run the tests.
 
-Modify this command to run a specific test: `phpunit --filter testCreateGetAndDelete tests/Api/NotesTest.php`
+Modify this command to run a specific test: `vendor/bin/phpunit --filter testCreateGetAndDelete tests/Api/NotesTest.php`
 
-Modify this command to run all tests in one class: `phpunit --filter test tests/Api/NotesTest.php`
+Modify this command to run all tests in one class: `vendor/bin/phpunit --filter test tests/Api/NotesTest.php`

--- a/lib/Exception/AbstractApiException.php
+++ b/lib/Exception/AbstractApiException.php
@@ -27,7 +27,7 @@ abstract class AbstractApiException extends \Exception
     {
         if (empty($message)) {
             // Use message appropriate to the subclass with late binding
-            $message = self::DEFAULT_MESSAGE;
+            $message = static::DEFAULT_MESSAGE;
         }
 
         parent::__construct($message, $code, $previous);

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -116,7 +116,7 @@ class Response
      */
     public function isHtml()
     {
-        return substr($this->body, 0, 1) === '<';
+        return substr(trim($this->body), 0, 1) === '<';
     }
 
     /**
@@ -158,7 +158,7 @@ class Response
     private function parseResponse($response)
     {
         $exploded = explode("\r\n\r\n", $response);
-        $this->body = trim(array_pop($exploded));
+        $this->body = array_pop($exploded);
         $this->headers = implode("\r\n\r\n", $exploded);
     }
 

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -123,7 +123,6 @@ class Response
      * @param string $path
      *
      * @return array
-     * @throws \Exception
      */
     public function saveToFile($path)
     {
@@ -170,7 +169,7 @@ class Response
     {
         if (!in_array($this->info['http_code'], array(200, 201))) {
             $message = 'The response has unexpected status code ('.$this->info['http_code'].').';
-            throw new UnexpectedResponseFormatException($this, $message);
+            throw new UnexpectedResponseFormatException($this, $message, $this->info['http_code']);
         }
 
         if ($this->isHtml()) {

--- a/tests/Api/CompanyFieldsTest.php
+++ b/tests/Api/CompanyFieldsTest.php
@@ -24,10 +24,8 @@ class CompanyFieldTest extends ContactFieldsTest
         );
     }
 
-    protected function assertPayloadList($response)
+    protected function assertFieldPayloadList($response)
     {
-        parent::assertPayloadList($response);
-
         if (!empty($response[$this->api->listName()])) {
             foreach ($response[$this->api->listName()] as $item) {
                 $this->assertSame('company', $item['object'], 'This field must be object of company '.print_r($item, true));

--- a/tests/Api/ContactFieldsTest.php
+++ b/tests/Api/ContactFieldsTest.php
@@ -25,7 +25,11 @@ class ContactFieldsTest extends MauticApiTestCase
     protected function assertPayloadList($response)
     {
         parent::assertPayloadList($response);
+        $this->assertFieldPayloadList($response);
+    }
 
+    protected function assertFieldPayloadList($response)
+    {
         if (!empty($response[$this->api->listName()])) {
             foreach ($response[$this->api->listName()] as $item) {
                 $this->assertSame('lead', $item['object'], 'This field must be object of lead '.print_r($item, true));

--- a/tests/Api/ContactsTest.php
+++ b/tests/Api/ContactsTest.php
@@ -240,18 +240,19 @@ class ContactsTest extends AbstractCustomFieldsTest
     {
         // Test Create
         $response = $this->api->create($this->testPayload);
+        $contact = $response[$this->api->itemName()];
 
         $this->assertPayload($response);
-        $this->assertEquals(count($response[$this->api->itemName()]['tags']), count($this->testPayload['tags']));
-        $this->assertEquals($response[$this->api->itemName()]['fields']['core']['firstname']['value'], $this->testPayload['firstname']);
-        $this->assertEquals($response[$this->api->itemName()]['fields']['core']['lastname']['value'], $this->testPayload['lastname']);
-        $this->assertEquals($response[$this->api->itemName()]['fields']['core']['address2']['value'], $this->testPayload['address2']);
-        $this->assertEquals($response[$this->api->itemName()]['fields']['all']['firstname'], $this->testPayload['firstname']);
-        $this->assertEquals($response[$this->api->itemName()]['fields']['all']['lastname'], $this->testPayload['lastname']);
-        $this->assertEquals($response[$this->api->itemName()]['fields']['all']['address2'], $this->testPayload['address2']);
+        $this->assertEquals(count($contact['tags']), count($this->testPayload['tags']));
+        $this->assertEquals($contact['fields']['core']['firstname']['value'], $this->testPayload['firstname']);
+        $this->assertEquals($contact['fields']['core']['lastname']['value'], $this->testPayload['lastname']);
+        $this->assertEquals($contact['fields']['core']['address2']['value'], $this->testPayload['address2']);
+        $this->assertEquals($contact['fields']['all']['firstname'], $this->testPayload['firstname']);
+        $this->assertEquals($contact['fields']['all']['lastname'], $this->testPayload['lastname']);
+        $this->assertEquals($contact['fields']['all']['address2'], $this->testPayload['address2']);
 
         // Test Get
-        $response = $this->api->get($response[$this->api->itemName()]['id']);
+        $response = $this->api->get($contact['id']);
         $this->assertPayload($response);
 
         // Test Delete
@@ -416,7 +417,19 @@ class ContactsTest extends AbstractCustomFieldsTest
 
     public function testBatchEndpoints()
     {
-        $this->standardTestBatchEndpoints();
+        $contact1 = $this->testPayload;
+        $contact2 = $this->testPayload;
+        $contact3 = $this->testPayload;
+        $contact1['email'] = 'batch1@test.email';
+        $contact2['email'] = 'batch2@test.email';
+        $contact3['email'] = 'batch3@test.email';
+        $batch = array(
+            $contact1,
+            $contact2,
+            $contact3,
+        );
+
+        $this->standardTestBatchEndpoints($batch);
     }
 
     public function testBCEndpoints()

--- a/tests/Api/ContactsTest.php
+++ b/tests/Api/ContactsTest.php
@@ -181,8 +181,12 @@ class ContactsTest extends AbstractCustomFieldsTest
         $this->assertErrors($response);
         $contact = $response[$this->api->itemName()];
 
+        // Add some activity
+        $this->api->addDnc($contact['id'], 'email', Contacts::BOUNCED);
+        $this->api->addPoints($contact['id'], 3);
+
         $response = $this->api->getActivityForContact($contact['id']);
-        $this->assertEventResponse($response, array('lead.create', 'lead.identified'));
+        $this->assertEventResponse($response, array('lead.donotcontact', 'point.gained'));
 
         $response = $this->api->delete($contact['id']);
         $this->assertErrors($response);
@@ -194,8 +198,12 @@ class ContactsTest extends AbstractCustomFieldsTest
         $this->assertErrors($response);
         $contact = $response[$this->api->itemName()];
 
-        $response = $this->api->getActivityForContact($contact['id'], '', array('lead.identified'));
-        $this->assertEventResponse($response, array('lead.identified'));
+        // Add some activity
+        $this->api->addDnc($contact['id'], 'email', Contacts::BOUNCED);
+        $this->api->addPoints($contact['id'], 3);
+
+        $response = $this->api->getActivityForContact($contact['id'], '', array('lead.donotcontact'));
+        $this->assertEventResponse($response, array('lead.donotcontact'));
 
         $response = $this->api->delete($contact['id']);
         $this->assertErrors($response);

--- a/tests/Api/ExceptionsTest.php
+++ b/tests/Api/ExceptionsTest.php
@@ -29,6 +29,7 @@ use Mautic\Exception\ActionNotSupportedException;
 use Mautic\Exception\RequiredParameterMissingException;
 use Mautic\Exception\UnexpectedResponseFormatException;
 use Mautic\Exception\IncorrectParametersReturnedException;
+use Mautic\Response;
 
 class ExceptionsTest extends MauticApiTestCase
 {
@@ -62,13 +63,13 @@ class ExceptionsTest extends MauticApiTestCase
 
     public function testUnexpectedResponseFormatException() {
         $expected = 'The response returned is in an unexpected format.';
-        $exception = new UnexpectedResponseFormatException();
+        $exception = new UnexpectedResponseFormatException(new Response('', []));
         $this->assertEquals($expected, $exception->getMessage(), 'This should return "'.$expected.'"' );
         $this->assertEquals(500, $exception->getCode());
     }
 
     public function testUnexpectedResponseFormatExceptionCustomMessage() {
-        $exception = new UnexpectedResponseFormatException(self::CUSTOM_ERROR_MESSAGE);
+        $exception = new UnexpectedResponseFormatException(new Response('', []), self::CUSTOM_ERROR_MESSAGE);
         $this->assertEquals(self::CUSTOM_ERROR_MESSAGE, $exception->getMessage(), 'This should return "'.self::CUSTOM_ERROR_MESSAGE.'"' );
         $this->assertEquals(500, $exception->getCode());
     }

--- a/tests/Api/ExceptionsTest.php
+++ b/tests/Api/ExceptionsTest.php
@@ -62,16 +62,22 @@ class ExceptionsTest extends MauticApiTestCase
     }
 
     public function testUnexpectedResponseFormatException() {
-        $expected = 'The response returned is in an unexpected format.';
-        $exception = new UnexpectedResponseFormatException(new Response('', []));
+        $expected = 'The response returned is in an unexpected format.'."\n\nResponse: ";
+        $exception = new UnexpectedResponseFormatException(new Response('', ['http_code' => 200]));
         $this->assertEquals($expected, $exception->getMessage(), 'This should return "'.$expected.'"' );
         $this->assertEquals(500, $exception->getCode());
     }
 
     public function testUnexpectedResponseFormatExceptionCustomMessage() {
-        $exception = new UnexpectedResponseFormatException(new Response('', []), self::CUSTOM_ERROR_MESSAGE);
-        $this->assertEquals(self::CUSTOM_ERROR_MESSAGE, $exception->getMessage(), 'This should return "'.self::CUSTOM_ERROR_MESSAGE.'"' );
+        $expected = self::CUSTOM_ERROR_MESSAGE."\n\nResponse: ";
+        $exception = new UnexpectedResponseFormatException(new Response('', ['http_code' => 200]), self::CUSTOM_ERROR_MESSAGE);
+        $this->assertEquals($expected, $exception->getMessage(), 'This should return "'.$expected.'"' );
         $this->assertEquals(500, $exception->getCode());
+    }
+
+    public function testUnexpectedResponseFormatExceptionCustomCode() {
+        $exception = new UnexpectedResponseFormatException(new Response('', ['http_code' => 200]), null, 404);
+        $this->assertEquals(404, $exception->getCode());
     }
 
     public function testIncorrectParametersReturnedException() {

--- a/tests/Api/FormsTest.php
+++ b/tests/Api/FormsTest.php
@@ -206,33 +206,33 @@ class FormsTest extends MauticApiTestCase
 
     public function testFormSubmissions()
     {
-        $form = $this->getFormWithMostSubmissions();
+        $formId = $this->getFormIdWithSomeSubmissions();
 
         // There are no forms in the testing Mautic instance. Ignore this test.
-        if (!$form) {
+        if (!$formId) {
             return;
         }
 
-        $response = $this->api->getSubmissions($form['id']);
+        $response = $this->api->getSubmissions($formId);
         $this->assertErrors($response);
 
         foreach ($response['submissions'] as $submission) {
-            $this->assertSubmission($submission, $form['id']);
+            $this->assertSubmission($submission, $formId);
         }
 
         // Try to fetch the last submission
-        $response = $this->api->getSubmission($form['id'], $submission['id']);
+        $response = $this->api->getSubmission($formId, $submission['id']);
         $this->assertErrors($response);
         $this->assertEquals($submission['id'], $response['submission']['id']);
-        $this->assertSubmission($response['submission'], $form['id']);
+        $this->assertSubmission($response['submission'], $formId);
 
         // Try to fetch submissions for the lead from the last submission
-        $response = $this->api->getSubmissionsForContact($form['id'], $submission['lead']['id']);
+        $response = $this->api->getSubmissionsForContact($formId, $submission['lead']['id']);
         $this->assertErrors($response);
 
         foreach ($response['submissions'] as $contactSubmission) {
             $this->assertEquals($submission['lead']['id'], $contactSubmission['lead']['id']);
-            $this->assertSubmission($contactSubmission, $form['id']);
+            $this->assertSubmission($contactSubmission, $formId);
         }
 
     }
@@ -242,17 +242,16 @@ class FormsTest extends MauticApiTestCase
         $this->assertEquals($formId, $submission['form']['id']);
         $this->assertTrue(!empty($submission['id']));
         $this->assertTrue(isset($submission['ipAddress']));
-        $this->assertTrue(isset($submission['lead']));
         $this->assertTrue(!empty($submission['dateSubmitted']));
         $this->assertTrue(isset($submission['referer']));
         $this->assertTrue(!empty($submission['results']));
     }
 
-    protected function getFormWithMostSubmissions()
+    protected function getFormIdWithSomeSubmissions()
     {
-        $response = $this->api->getList('', 0, 1, 'submission_count', 'DESC');
+        $response = $this->getContext('stats')->get('form_submissions', 0, 1);
         $this->assertErrors($response);
 
-        return isset($response['forms'][0]) ? $response['forms'][0] : null;
+        return isset($response['stats'][0]['form_id']) ? $response['stats'][0]['form_id'] : null;
     }
 }

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -115,9 +115,9 @@ Content-Type: text/html; charset=UTF-8';
 
     public function testParseResponse()
     {
-        $response = new Response($this->getHtmlResponse(), $this->getInfo());
+        $response = new Response($this->getJsonResponse(), $this->getInfo());
         $this->assertSame($this->headersWithRedirects, $response->getHeaders());
-        $this->assertSame($this->htmlBody, $response->getBody());
+        $this->assertSame($this->jsonBody, $response->getBody());
         $this->assertSame($this->getInfo(), $response->getInfo());
     }
 
@@ -125,6 +125,15 @@ Content-Type: text/html; charset=UTF-8';
     {
         $this->expectException(UnexpectedResponseFormatException::class);
         $response = new Response($this->getHtmlResponse(), $this->getInfo(500));
+    }
+
+    public function testValidation404()
+    {
+        try {
+            $response = new Response($this->getHtmlResponse(), $this->getInfo(404));
+        } catch(UnexpectedResponseFormatException $e) {
+            $this->assertSame(404, $e->getCode());
+        }
     }
 
     public function testDecodeFromUrlParamsWithParams()
@@ -165,15 +174,15 @@ Content-Type: text/html; charset=UTF-8';
     public function testDecodeFromJsonWithEmptyResponse()
     {
         $response = new Response($this->headersWithRedirects.$this->space, $this->getInfo());
+        $this->expectException(UnexpectedResponseFormatException::class);
         $body = $response->getDecodedBody();
-        $this->assertSame('', $body);
     }
 
     public function testDecodeFromJsonWithTextResponse()
     {
         $response = new Response($this->headersWithRedirects.$this->space.'OK', $this->getInfo());
+        $this->expectException(UnexpectedResponseFormatException::class);
         $body = $response->getDecodedBody();
-        $this->assertSame('OK', $body);
     }
 
     public function testSaveToFile()


### PR DESCRIPTION
This PR adds HTTP code to the thrown exception and since I noticed some unit tests are failing this contains fixes of those failures as well.

Checkout your dev Mautic to use this fix: https://github.com/mautic/mautic/pull/5520

Run `vendor/bin/phpunit` and all tests should pass.