### PR TITLE
Update for Contacts getIdentified

### DIFF
--- a/lib/Api/Contacts.php
+++ b/lib/Api/Contacts.php
@@ -83,7 +83,7 @@ class Contacts extends Api
      */
     public function getIdentified($search = '', $start = 0, $limit = 0, $orderBy = '', $orderByDir = 'ASC', $publishedOnly = false, $minimal = false)
     {
-        $search .= ($search) ? "$search !is:anonymous" : '!is:anonymous';
+        $search = ($search) ? "$search !is:anonymous" : '!is:anonymous';
 
         return $this->getList($search, $start, $limit, $orderBy, $orderByDir, $publishedOnly, $minimal);
     }


### PR DESCRIPTION
The Problem here is that the searchstring gets repeatet.
`$contactApi->getIdentified(some@ma.il);`
will end up in a searchstring like:
`some@ma.ilsome@ma.il !is:anonymous`

This way no client is found.