### PR TITLE
Email subject is required now. Some tests were failing because of it

### DIFF
--- a/tests/Api/CampaignsTest.php
+++ b/tests/Api/CampaignsTest.php
@@ -34,6 +34,7 @@ class CampaignsTest extends MauticApiTestCase
             'item' => 'email',
             'payload' => array(
                 'name' => 'Company API test',
+                'subject' => 'Company API test',
                 'body' => 'Company API test'
             )
         ),

--- a/tests/Api/MessagesTest.php
+++ b/tests/Api/MessagesTest.php
@@ -47,6 +47,7 @@ class MessagesTest extends MauticApiTestCase
             $response = $api->create(
                 array(
                     'name' => 'MM API test', // required for all
+                    'subject' => 'MM API test', // required for email
                     'message' => 'test', // required for sms
                     'heading' => 'test' // required for notifications
                 )


### PR DESCRIPTION
Try to run the tests against current Mautic staging (2.13.0 - prerelease) and some marketing message and email tests will fail. Checkout this PR and they will pass.