### PR TITLE
SMS send to contact GET method

### DIFF
--- a/lib/Api/Smses.php
+++ b/lib/Api/Smses.php
@@ -53,6 +53,6 @@ class Smses extends Api
      */
     public function sendToContact($id, $contactId)
     {
-        return $this->makeRequest($this->endpoint.'/'.$id.'/contact/'.$contactId.'/send', array(), 'POST');
+        return $this->makeRequest($this->endpoint.'/'.$id.'/contact/'.$contactId.'/send');
     }
 }


### PR DESCRIPTION
In last mautic version send SMS to contact expects GET method and not POST. So the method `sendToContact` always responses with 404. Not sure if it is must be fixed in library or on Mautic side.