### PR TITLE
Use assertEquals instead of assertSame to ensure arrays with a differ...

### DIFF
--- a/tests/Api/MauticApiTestCase.php
+++ b/tests/Api/MauticApiTestCase.php
@@ -167,7 +167,7 @@ abstract class MauticApiTestCase extends \PHPUnit_Framework_TestCase
                 )
             );
 
-            $this->assertSame($item[$itemProp], $itemVal, '>>> '.$itemProp.':');
+            $this->assertEquals($item[$itemProp], $itemVal, '>>> '.$itemProp.':');
         }
     }
 


### PR DESCRIPTION
…ent ordered keys pass the test

Fixes #208 