### PR TITLE
Fix getMauticVersion() command

### DIFF
--- a/lib/Api/Api.php
+++ b/lib/Api/Api.php
@@ -10,8 +10,7 @@
 
 namespace Mautic\Api;
 
-use Mautic\Auth\ApiAuth;
-use Mautic\Auth\AuthInterface;
+use Mautic\Auth\AbstractAuth;
 use Mautic\QueryBuilder\QueryBuilder;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
@@ -86,7 +85,7 @@ class Api implements LoggerAwareInterface
     protected $searchCommands = [];
 
     /**
-     * @var ApiAuth
+     * @var AbstractAuth
      */
     private $auth;
 
@@ -98,7 +97,7 @@ class Api implements LoggerAwareInterface
     /**
      * @param string $baseUrl
      */
-    public function __construct(AuthInterface $auth, $baseUrl = '')
+    public function __construct(AbstractAuth $auth, $baseUrl = '')
     {
         $this->auth = $auth;
         $this->setBaseUrl($baseUrl);
@@ -336,10 +335,10 @@ class Api implements LoggerAwareInterface
      */
     public function getMauticVersion()
     {
-        $headers = $this->auth->getResponseHeaders();
+        $headers = array_change_key_case($this->auth->getResponseHeaders(), CASE_LOWER);
 
-        if (isset($headers['Mautic-Version'])) {
-            return $headers['Mautic-Version'];
+        if (isset($headers['mautic-version'])) {
+            return $headers['mautic-version'];
         }
 
         return null;


### PR DESCRIPTION
Fixes https://github.com/mautic/api-library/issues/233

Ensures that the `mautic-version` header key is always converted to lowercase prior to checking if it exists. This makes the `getMauticVersion()` command less error-prone.