### PR TITLE
Allow testing specific PR in Actions workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,8 @@ jobs:
           gh pr checkout ${{ github.event.inputs.pr }}
           popd
         fi
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
     - name: Move files to web root
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,10 @@ on:
       - '[0-9]+\.[0-9]+'
   pull_request:
   workflow_dispatch:
+    inputs:
+      pr:
+        description: 'PR number in mautic/mautic to test against'
+        required: false
   schedule:
     # Run every day at 10 AM UTC to discover potential issues with recent changes to Mautic itself
     - cron: '0 10 * * *'
@@ -73,8 +77,14 @@ jobs:
         composer validate --strict
         composer install --prefer-dist --no-progress
 
-    - name: Clone Mautic features branch from GitHub
-      run: git clone -b features --single-branch --depth 1 https://github.com/mautic/mautic.git mautic
+    - name: Clone Mautic features or specific PR from GitHub
+      run: |
+        gh repo clone mautic/mautic -- --branch features --single-branch --depth 1
+        if [[ "${{ github.event.inputs.pr }}" != "" ]]; then
+          pushd mautic
+          gh pr checkout ${{ github.event.inputs.pr }}
+          popd
+        fi
 
     - name: Move files to web root
       run: |


### PR DESCRIPTION
Closes #255 

After merging this PR, then manually kicking off the API library tests, it will be possible to specify a specific PR from `mautic/mautic` to test against 🎉 

![image](https://user-images.githubusercontent.com/17739158/125640386-13a88908-337c-4537-983d-e1417dce5ed9.png)

Example run which tests against https://github.com/mautic/mautic/pull/10259: https://github.com/mautic/api-library/actions/runs/1030643520
