### PR TITLE
No longer need to force PHP 7.4.25 in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 7.4.25
+        php-version: 7.4
         ini-values: session.save_handler=redis, session.save_path="tcp://127.0.0.1:6379"
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
         coverage: pcov


### PR DESCRIPTION
This has been fixed upstream in the meantime: https://github.com/oerdnj/deb.sury.org/issues/1682