### PR TITLE
Replacing abandoned kint-php/kint library with its successor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "psr/log": "~1.0"
   },
   "require-dev": {
-    "raveren/kint": "~0.9",
+    "kint-php/kint": "^4.1",
     "friendsofphp/php-cs-fixer": "~2.16.1",
     "phpunit/phpunit": "~9.5.0",
     "brianium/paratest": "^6.2"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "12efc0f4bf879266563111bdc11dd051",
+    "content-hash": "3b3914d2f9cd22a739f26aaef74c001d",
     "packages": [
         {
             "name": "psr/log",
@@ -605,6 +605,66 @@
                 }
             ],
             "time": "2020-12-17T16:34:40+00:00"
+        },
+        {
+            "name": "kint-php/kint",
+            "version": "4.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kint-php/kint.git",
+                "reference": "e64b939f9ceb9620abd982e2a66a3289fcf4e837"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kint-php/kint/zipball/e64b939f9ceb9620abd982e2a66a3289fcf4e837",
+                "reference": "e64b939f9ceb9620abd982e2a66a3289fcf4e837",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "phpspec/prophecy-phpunit": "^2",
+                "phpunit/phpunit": "^9.0",
+                "seld/phar-utils": "^1.0",
+                "symfony/finder": "^3.0 || ^4.0 || ^5.0",
+                "vimeo/psalm": "^4.0"
+            },
+            "suggest": {
+                "kint-php/kint-twig": "Provides d() and s() functions in twig templates"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "init.php"
+                ],
+                "psr-4": {
+                    "Kint\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jonathan Vollebregt",
+                    "homepage": "https://github.com/jnvsor"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/kint-php/kint/graphs/contributors"
+                }
+            ],
+            "description": "Kint - debugging tool for PHP developers",
+            "homepage": "https://kint-php.github.io/kint/",
+            "keywords": [
+                "debug",
+                "kint",
+                "php"
+            ],
+            "time": "2022-01-02T10:30:48+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -1618,62 +1678,6 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
-        },
-        {
-            "name": "raveren/kint",
-            "version": "v0.9.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/raveren/kint.git",
-                "reference": "d4780fc6e974f00c427c1fd2492dca4dcd636704"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/raveren/kint/zipball/d4780fc6e974f00c427c1fd2492dca4dcd636704",
-                "reference": "d4780fc6e974f00c427c1fd2492dca4dcd636704",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "0.9-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "Kint.class.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Rokas Šleinius",
-                    "homepage": "https://github.com/raveren"
-                },
-                {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/raveren/kint/contributors"
-                }
-            ],
-            "description": "Kint - debugging helper for PHP developers",
-            "homepage": "https://github.com/raveren/kint",
-            "keywords": [
-                "debug",
-                "kint",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/raveren/kint/issues",
-                "source": "https://github.com/raveren/kint/tree/v0.9.1"
-            },
-            "abandoned": "kint-php/kint",
-            "time": "2014-08-11T11:44:51+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3b3914d2f9cd22a739f26aaef74c001d",
+    "content-hash": "94a408e9a31c19781f839dfa7847a76b",
     "packages": [
         {
             "name": "psr/log",


### PR DESCRIPTION
The GH Actions are failing with
```
Downloading raveren/kint (v0.9.1)
    Failed to download raveren/kint from dist: The "https://codeload.github.com/raveren/kint/legacy.zip/d4780fc6e974f00c427c1fd2492dca4dcd636704" file could not be downloaded (HTTP/2 404 )

Error: Failed to execute git checkout 'd4780fc6e974f00c427c1fd2492dca4dcd636704' -- && git reset --hard 'd4780fc6e974f00c427c1fd2492dca4dcd636704' --

fatal: reference is not a tree: d4780fc6e974f00c427c1fd2492dca4dcd636704
```

As https://packagist.org/packages/raveren/kint is abandoned and https://packagist.org/packages/kint-php/kint is suggested as a replacement I did just that:
```
$ composer remove raveren/kint --dev
Loading composer repositories with package information
Updating dependencies (including require-dev)
Nothing to install or update
Writing lock file
Generating autoload files
```
```
$ composer require --dev kint-php/kint
Using version ^4.1 for kint-php/kint
./composer.json has been updated
Loading composer repositories with package information
Warning from https://repo.packagist.org: Support for Composer 1 is deprecated and some packages will not be available. You should upgrade to Composer 2. See https://blog.packagist.com/deprecating-composer-1-support/
Updating dependencies (including require-dev)
Package operations: 1 install, 0 updates, 0 removals
  - Installing kint-php/kint (4.1.1): Downloading (100%)         
kint-php/kint suggests installing kint-php/kint-twig (Provides d() and s() functions in twig templates)
Writing lock file
Generating autoload files
````

The lock was out of sync after the commands above 🤷  so I did this:
```
$ composer validate --strict
./composer.json is valid
The lock file is not up to date with the latest changes in composer.json, it is recommended that you run `composer update` or `composer update <package name>`.

$ composer update kint-php/kint
Loading composer repositories with package information
Updating dependencies (including require-dev)
Nothing to install or update
Writing lock file
Generating autoload files
48 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
~/dev/api-library (replacing-abandoned-kint-library) $ composer validate --strict   
./composer.json is valid
```
And the error was gone.