### PR TITLE
Use default `mautic/mautic` branch instead of `features`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,9 +77,9 @@ jobs:
         composer validate --strict
         composer install --prefer-dist --no-progress
 
-    - name: Clone Mautic features or specific PR from GitHub
+    - name: Clone Mautic main branch or specific PR from GitHub
       run: |
-        gh repo clone mautic/mautic -- --branch features --single-branch --depth 1
+        gh repo clone mautic/mautic -- --single-branch --depth 1
         if [[ "${{ github.event.inputs.pr }}" != "" ]]; then
           pushd mautic
           gh pr checkout ${{ github.event.inputs.pr }}


### PR DESCRIPTION
The API tests have been running against the `features` branch all this time 🤦🏼‍♂️ let's simply test against the default branch moving forward (which is 4.x at the time of writing, but _will_ change eventually).

CI will obviously fail on this one because _lots_ of changes were introduced in Mautic in the meantime.