### PR TITLE
fix failing in tests

### DIFF
--- a/.github/ci-files/local.config.php
+++ b/.github/ci-files/local.config.php
@@ -52,10 +52,10 @@ return [
     'version'           => 'OAuth1a',
 
     // Required for OAuth1a and OAuth2
-    'baseUrl'           => 'http://localhost/mautic/index_dev.php',
+    'baseUrl'           => 'http://localhost/index_dev.php',
 
     // Required for All tests
-    'apiUrl'            => 'http://localhost/mautic/index_dev.php/api/',
+    'apiUrl'            => 'http://localhost/index_dev.php/api/',
     // Required for EmailsTest
     'testEmail'         => 'notexisting@email.com',
 

--- a/.github/workflows/mautic-apache.conf
+++ b/.github/workflows/mautic-apache.conf
@@ -1,5 +1,0 @@
-<Directory /var/www/html/>
-        Options Indexes FollowSymLinks
-        AllowOverride All
-        Require all granted
-</Directory>

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,8 +65,6 @@ jobs:
         sudo add-apt-repository ppa:ondrej/apache2 -y
         sudo apt-get install apache2 libapache2-mod-php7.4
         sudo a2enmod rewrite
-        sudo cp ./.github/workflows/mautic-apache.conf /etc/apache2/conf-available/mautic.conf
-        sudo a2enconf mautic
         sudo sed -i 's,^session.save_handler =.*$,session.save_handler = redis,' /etc/php/7.4/apache2/php.ini
         sudo sed -i 's,^;session.save_path =.*$,session.save_path = "tcp://127.0.0.1:6379",' /etc/php/7.4/apache2/php.ini
         sudo service apache2 restart
@@ -94,8 +92,7 @@ jobs:
         sudo chmod -R 777 /var/www/html
         sudo chown -R www-data:www-data /var/www/html
         rm -rf /var/www/html/*
-        mkdir -p /var/www/html/mautic
-        mv $GITHUB_WORKSPACE/mautic/* /var/www/html/mautic
+        mv $GITHUB_WORKSPACE/mautic/* /var/www/html/
 
     - name: Install Mautic
       env:
@@ -103,21 +100,20 @@ jobs:
       run: |
         composer install --prefer-dist --no-progress
         cp $GITHUB_WORKSPACE/.github/ci-files/local.php ./app/config/local.php
-        php bin/console mautic:install http://localhost/mautic \
+        php bin/console mautic:install http://localhost/ \
           --force --mailer_from_name="GitHub Actions" --mailer_from_email="github-actions@mautic.org" \
           --mailer_transport="smtp" --mailer_host="localhost" --mailer_port="1025"
         php bin/console cache:warmup --no-interaction --env=dev
-        
-        sudo chmod -R 777 /var/www/html/mautic
-        sudo chown -R www-data:www-data /var/www/html/mautic
-      working-directory: /var/www/html/mautic
+        sudo chown -R www-data:www-data /var/www/html
+
+      working-directory: /var/www/html/
 
       # Enable Twilio plugin with random credentials (needed for MessagesTest to function, doesn't actually contact Twilio API).
     - name: Enable Twilio plugin
       run: |
-        mysql -uroot -P${{ job.services.mysql.ports[3306] }} -h127.0.0.1 -e "USE mautictest; INSERT INTO plugin_integration_settings (id, plugin_id, name, is_published, supported_features, api_keys, feature_settings) VALUES (2, NULL, 'Twilio', 1, 'a:0:{}', 'a:2:{s:8:\"username\";s:169:\"bzFmNlIydWRSZXlIN2lQVkdpanJ4aTQ2NUh6RVdDbHlLRVhsWGZ4b0kyZVNxLzYrQ1J6V1RvMnlhVEp0c245TEp6eStQekx5ZVhLWjB1YVdoR3RnR2dHQ3k1emVVdGt5NzZKUmtjUnJ3c1E9|L8tbZRIYhwatT7Mq+HAdYA==\";s:8:\"password\";s:169:\"T2d2cFpXQWE5YVZnNFFianJSYURRYUtGRHBNZGZjM1VETXg2Wm5Va3NheW43MjVWUlJhTVlCL2pYMDBpbElONStiVVBNbEM3M3BaeGJMNkFKNUFEN1pTNldSRjc4bUM4SDh1SE9OY1k5MTg9|TeuSvfx4XSUOvp0O7T49Cg==\";}', 'a:4:{s:20:\"sending_phone_number\";N;s:22:\"disable_trackable_urls\";i:0;s:16:\"frequency_number\";N;s:14:\"frequency_time\";N;}');"
+        mysql -uroot -P${{ job.services.mysql.ports[3306] }} -h127.0.0.1 -e "USE mautictest; INSERT INTO plugin_integration_settings (plugin_id, name, is_published, supported_features, api_keys, feature_settings) VALUES (NULL, 'Twilio', 1, 'a:0:{}', 'a:2:{s:8:\"username\";s:169:\"bzFmNlIydWRSZXlIN2lQVkdpanJ4aTQ2NUh6RVdDbHlLRVhsWGZ4b0kyZVNxLzYrQ1J6V1RvMnlhVEp0c245TEp6eStQekx5ZVhLWjB1YVdoR3RnR2dHQ3k1emVVdGt5NzZKUmtjUnJ3c1E9|L8tbZRIYhwatT7Mq+HAdYA==\";s:8:\"password\";s:169:\"T2d2cFpXQWE5YVZnNFFianJSYURRYUtGRHBNZGZjM1VETXg2Wm5Va3NheW43MjVWUlJhTVlCL2pYMDBpbElONStiVVBNbEM3M3BaeGJMNkFKNUFEN1pTNldSRjc4bUM4SDh1SE9OY1k5MTg9|TeuSvfx4XSUOvp0O7T49Cg==\";}', 'a:4:{s:20:\"sending_phone_number\";N;s:22:\"disable_trackable_urls\";i:0;s:16:\"frequency_number\";N;s:14:\"frequency_time\";N;}');"
         php bin/console mautic:plugins:reload
-      working-directory: /var/www/html/mautic
+      working-directory: /var/www/html
     
     - name: Run tests
       run: vendor/bin/paratest -p 3 --coverage-clover coverage.xml
@@ -130,7 +126,7 @@ jobs:
       if: always()
       with:
         name: mautic-logs
-        path: /var/www/html/mautic/var/logs/
+        path: /var/www/html/var/logs/
 
     - name: Slack Notification if tests fail
       uses: rtCamp/action-slack-notify@v2

--- a/lib/Api/Stats.php
+++ b/lib/Api/Stats.php
@@ -45,7 +45,12 @@ class Stats extends Api
 
         $parameters = array_filter($parameters);
 
-        return $this->makeRequest($this->endpoint.'/'.$table, $parameters);
+        $endpoint = $this->endpoint;
+        if ($table) {
+            $endpoint .= '/'.$table;
+        }
+
+        return $this->makeRequest($endpoint, $parameters);
     }
 
     /**

--- a/tests/Api/MauticApiTestCase.php
+++ b/tests/Api/MauticApiTestCase.php
@@ -165,7 +165,7 @@ abstract class MauticApiTestCase extends TestCase
                 )
             );
 
-            $this->assertEquals($item[$itemProp], $itemVal, '>>> '.$itemProp.':');
+            $this->assertEquals($itemVal, $item[$itemProp], '>>> '.$itemProp.':');
         }
     }
 

--- a/tests/Api/SegmentsTest.php
+++ b/tests/Api/SegmentsTest.php
@@ -160,6 +160,16 @@ class SegmentsTest extends MauticApiTestCase
 
     public function testBatchEndpoints()
     {
-        $this->standardTestBatchEndpoints();
+        $this->standardTestBatchEndpoints(null, function ($response, &$batch, $action) {
+            switch ($action) {
+                // Add extra values to the batch after create, as the API returns them in the response.
+                // This is probably related to https://github.com/mautic/mautic/pull/8649
+                case 'create':
+                    foreach ($batch as &$item) {
+                        $item['filters'][0] += ['filter' => '*@gmail.com', 'display' => null];
+                    }
+                    break;
+            }
+        });
     }
 }

--- a/tests/Api/SegmentsTest.php
+++ b/tests/Api/SegmentsTest.php
@@ -28,13 +28,14 @@ class SegmentsTest extends MauticApiTestCase
             'isGlobal'    => true,
             'filters'     => [
                 [
-                    'glue'     => 'and',
-                    'field'    => 'email',
-                    'object'   => 'lead',
-                    'type'     => 'email',
-                    'filter'   => '*@gmail.com',
-                    'display'  => null,
-                    'operator' => 'like',
+                    'glue'       => 'and',
+                    'field'      => 'email',
+                    'object'     => 'lead',
+                    'type'       => 'email',
+                    'properties' => [
+                        'filter'   => '*@gmail.com',
+                    ],
+                    'operator'   => 'like',
                 ],
             ],
         ];


### PR DESCRIPTION
addressed issues:
* Mautic was installed in a subdir, which isn't compatible with the default .htaccess, resulting in 403 errors
* the Twilio db insertion had a hardcoded id, which is not ideal if other plugins are already defined in that table
* the `stats` endpoint has a trailing slash, resulting a redirect, that the api doesn't handle correclty
* fixed the order in `assertPayloadItem` to correctly show the `Expected` and `Actual` values in failing tests
* changed segment tests to be compatible with https://github.com/mautic/mautic/pull/8649
* add workaround for batch segment tests