### PR TITLE
Correct mautic env

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -104,8 +104,6 @@ jobs:
           --force --mailer_from_name="GitHub Actions" --mailer_from_email="github-actions@mautic.org" \
           --mailer_transport="smtp" --mailer_host="localhost" --mailer_port="1025" --env=dev
         php bin/console cache:warmup --no-interaction --env=dev
-        sudo chown -R www-data:www-data /var/www/html
-
       working-directory: /var/www/html/
 
       # Enable Twilio plugin with random credentials (needed for MessagesTest to function, doesn't actually contact Twilio API).
@@ -114,6 +112,9 @@ jobs:
         mysql -uroot -P${{ job.services.mysql.ports[3306] }} -h127.0.0.1 -e "USE mautictest; INSERT INTO plugin_integration_settings (plugin_id, name, is_published, supported_features, api_keys, feature_settings) VALUES (NULL, 'Twilio', 1, 'a:0:{}', 'a:2:{s:8:\"username\";s:169:\"bzFmNlIydWRSZXlIN2lQVkdpanJ4aTQ2NUh6RVdDbHlLRVhsWGZ4b0kyZVNxLzYrQ1J6V1RvMnlhVEp0c245TEp6eStQekx5ZVhLWjB1YVdoR3RnR2dHQ3k1emVVdGt5NzZKUmtjUnJ3c1E9|L8tbZRIYhwatT7Mq+HAdYA==\";s:8:\"password\";s:169:\"T2d2cFpXQWE5YVZnNFFianJSYURRYUtGRHBNZGZjM1VETXg2Wm5Va3NheW43MjVWUlJhTVlCL2pYMDBpbElONStiVVBNbEM3M3BaeGJMNkFKNUFEN1pTNldSRjc4bUM4SDh1SE9OY1k5MTg9|TeuSvfx4XSUOvp0O7T49Cg==\";}', 'a:4:{s:20:\"sending_phone_number\";N;s:22:\"disable_trackable_urls\";i:0;s:16:\"frequency_number\";N;s:14:\"frequency_time\";N;}');"
         php bin/console mautic:plugins:reload --env=dev
       working-directory: /var/www/html
+
+    - name: Set correct ownership so Apache can access the files
+      run: sudo chown -R www-data:www-data /var/www/html
     
     - name: Run tests
       run: vendor/bin/paratest -p 3 --coverage-clover coverage.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,7 +102,7 @@ jobs:
         cp $GITHUB_WORKSPACE/.github/ci-files/local.php ./app/config/local.php
         php bin/console mautic:install http://localhost/ \
           --force --mailer_from_name="GitHub Actions" --mailer_from_email="github-actions@mautic.org" \
-          --mailer_transport="smtp" --mailer_host="localhost" --mailer_port="1025"
+          --mailer_transport="smtp" --mailer_host="localhost" --mailer_port="1025" --env=dev
         php bin/console cache:warmup --no-interaction --env=dev
         sudo chown -R www-data:www-data /var/www/html
 
@@ -112,7 +112,7 @@ jobs:
     - name: Enable Twilio plugin
       run: |
         mysql -uroot -P${{ job.services.mysql.ports[3306] }} -h127.0.0.1 -e "USE mautictest; INSERT INTO plugin_integration_settings (plugin_id, name, is_published, supported_features, api_keys, feature_settings) VALUES (NULL, 'Twilio', 1, 'a:0:{}', 'a:2:{s:8:\"username\";s:169:\"bzFmNlIydWRSZXlIN2lQVkdpanJ4aTQ2NUh6RVdDbHlLRVhsWGZ4b0kyZVNxLzYrQ1J6V1RvMnlhVEp0c245TEp6eStQekx5ZVhLWjB1YVdoR3RnR2dHQ3k1emVVdGt5NzZKUmtjUnJ3c1E9|L8tbZRIYhwatT7Mq+HAdYA==\";s:8:\"password\";s:169:\"T2d2cFpXQWE5YVZnNFFianJSYURRYUtGRHBNZGZjM1VETXg2Wm5Va3NheW43MjVWUlJhTVlCL2pYMDBpbElONStiVVBNbEM3M3BaeGJMNkFKNUFEN1pTNldSRjc4bUM4SDh1SE9OY1k5MTg9|TeuSvfx4XSUOvp0O7T49Cg==\";}', 'a:4:{s:20:\"sending_phone_number\";N;s:22:\"disable_trackable_urls\";i:0;s:16:\"frequency_number\";N;s:14:\"frequency_time\";N;}');"
-        php bin/console mautic:plugins:reload
+        php bin/console mautic:plugins:reload --env=dev
       working-directory: /var/www/html
     
     - name: Run tests


### PR DESCRIPTION
Since https://github.com/mautic/mautic/pull/11498 was merged, the api tests seems to fail.

This is caused because Mautic is installed in the `test` env (using md5 hashing for passwords), but is consumed in the `dev` env using bcrypt.

This PR ensures Mautic is installed in dev env