### PR TITLE
Bump PHP version to mitigate the broken tests

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,7 +1,7 @@
 name: api-library
 type: php
 docroot: ""
-php_version: "7.4"
+php_version: "8.0"
 webserver_type: apache-fpm
 router_http_port: "80"
 router_https_port: "443"
@@ -13,7 +13,7 @@ mysql_version: ""
 provider: default
 use_dns_when_possible: true
 composer_version: "2"
-webimage_extra_packages: [php7.4-imap]
+webimage_extra_packages: [php8.0-imap]
 hooks:
   post-start:
     - exec: "./.ddev/mautic-setup.sh"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 7.4
+        php-version: 8.0
         ini-values: session.save_handler=redis, session.save_path="tcp://127.0.0.1:6379"
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
         coverage: pcov
@@ -63,12 +63,12 @@ jobs:
       run: |
         sudo add-apt-repository ppa:ondrej/php -y
         sudo add-apt-repository ppa:ondrej/apache2 -y
-        sudo apt-get install apache2 libapache2-mod-php7.4
+        sudo apt-get install apache2 libapache2-mod-php8.0
         sudo a2enmod rewrite
-        sudo sed -i 's,^session.save_handler =.*$,session.save_handler = redis,' /etc/php/7.4/apache2/php.ini
-        sudo sed -i 's,^;session.save_path =.*$,session.save_path = "tcp://127.0.0.1:6379",' /etc/php/7.4/apache2/php.ini
+        sudo sed -i 's,^session.save_handler =.*$,session.save_handler = redis,' /etc/php/8.0/apache2/php.ini
+        sudo sed -i 's,^;session.save_path =.*$,session.save_path = "tcp://127.0.0.1:6379",' /etc/php/8.0/apache2/php.ini
         sudo service apache2 restart
-        cat /etc/php/7.4/apache2/php.ini | grep session
+        cat /etc/php/8.0/apache2/php.ini | grep session
 
     - name: Install dependencies
       run: |
@@ -146,7 +146,7 @@ jobs:
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 7.4
+        php-version: 8.0
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
 
     - name: Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,10 @@
   },
   "scripts": {
     "test": "vendor/bin/paratest"
+  },
+  "config": {
+    "platform": {
+      "php": "7.4"
+    }
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f0a1c55665367db1d432c91dbb1d8ca6",
+    "content-hash": "b2baec0192075c5c3c211e125c97a689",
     "packages": [
         {
             "name": "psr/log",
@@ -957,6 +957,7 @@
                 "issues": "https://github.com/PHP-CS-Fixer/diff/issues",
                 "source": "https://github.com/PHP-CS-Fixer/diff/tree/v1.3.1"
             },
+            "abandoned": true,
             "time": "2020-10-14T08:39:05+00:00"
         },
         {
@@ -4293,5 +4294,8 @@
         "ext-json": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "platform-overrides": {
+        "php": "7.4"
+    },
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
This is a temp fix to make the tests work again.

Currently the same PHP version is used both for API and the Mautic instance.
The API should be tested against multiple PHP version, regardless of the PHP version Mautic version.