### PR TITLE
Fix - Deprecated PHP 8.1

### DIFF
--- a/lib/Auth/OAuth.php
+++ b/lib/Auth/OAuth.php
@@ -385,14 +385,14 @@ class OAuth extends AbstractAuth
         }
 
         //Check for existing access token
-        if ($this->_access_token && strlen($this->_access_token) > 0) {
+        if ($this->_access_token) {
             $this->log('has access token');
 
             return true;
         }
 
         //Reauthorize if no token was found
-        if (!$this->_access_token || 0 == strlen($this->_access_token)) {
+        if (!$this->_access_token) {
             $this->log('access token empty so authorize');
 
             //OAuth flows
@@ -522,7 +522,7 @@ class OAuth extends AbstractAuth
      */
     protected function isOauth1()
     {
-        return !empty($this->_request_token_url) && strlen($this->_request_token_url) > 0;
+        return !empty($this->_request_token_url);
     }
 
     /**
@@ -634,7 +634,7 @@ class OAuth extends AbstractAuth
                 $parameters['code'] = $_GET['code'];
             }
 
-            if ($this->_refresh_token && strlen($this->_refresh_token) > 0) {
+            if ($this->_refresh_token) {
                 $this->log('Using refresh token');
                 $parameters['grant_type']    = 'refresh_token';
                 $parameters['refresh_token'] = $this->_refresh_token;

--- a/lib/Auth/OAuth.php
+++ b/lib/Auth/OAuth.php
@@ -385,14 +385,14 @@ class OAuth extends AbstractAuth
         }
 
         //Check for existing access token
-        if (strlen($this->_access_token) > 0) {
+        if ($this->_access_token && strlen($this->_access_token) > 0) {
             $this->log('has access token');
 
             return true;
         }
 
         //Reauthorize if no token was found
-        if (0 == strlen($this->_access_token)) {
+        if (!$this->_access_token || 0 == strlen($this->_access_token)) {
             $this->log('access token empty so authorize');
 
             //OAuth flows
@@ -634,7 +634,7 @@ class OAuth extends AbstractAuth
                 $parameters['code'] = $_GET['code'];
             }
 
-            if (strlen($this->_refresh_token) > 0) {
+            if ($this->_refresh_token && strlen($this->_refresh_token) > 0) {
                 $this->log('Using refresh token');
                 $parameters['grant_type']    = 'refresh_token';
                 $parameters['refresh_token'] = $this->_refresh_token;


### PR DESCRIPTION
Fix for 
Deprecated
: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in api-library/lib/Auth/OAuth.php on 
- line 388
- line 395
- line 637