### PR TITLE
build: add .php-cs-fixer.cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 /tests/phpunit.phar
 /vendor
 .DS_Store
+/.php-cs-fixer.cache
 .phpunit.result.cache
 /.ddev/mautic-preference
 /mautic


### PR DESCRIPTION
When you run PHP-CS-Fixer this file is created, which should not be in VCS, so I added it to the `.gitignore`.