### PR TITLE
make the test flow compatible with removed email step

### DIFF
--- a/.ddev/mautic-local.php.dist
+++ b/.ddev/mautic-local.php.dist
@@ -14,4 +14,9 @@ $parameters = [
     'db_password'           => 'db',
     'admin_email'           => 'mautic@ddev.local',
     'admin_password'        => 'mautic',
+	'mailer_from_name'      => 'DDEV',
+	'mailer_from_email'     => 'mautic@ddev.local',
+	'mailer_transport'      => 'smtp',
+	'mailer_host'           => 'localhost',
+	'mailer_port'           => '1025',
 ];

--- a/.ddev/mautic-setup.sh
+++ b/.ddev/mautic-setup.sh
@@ -11,9 +11,7 @@ setup_mautic() {
     cp ../.ddev/mautic-local.php.dist ./app/config/local.php
 
     printf "Installing Mautic...\n"
-    php bin/console mautic:install --force http://localhost/mautic \
-        --mailer_from_name="DDEV" --mailer_from_email="mautic@ddev.local" \
-        --mailer_transport="smtp" --mailer_host="localhost" --mailer_port="1025"
+    php bin/console mautic:install --force http://localhost/mautic
     php bin/console cache:warmup --no-interaction --env=dev
 
     printf "Enabling Twilio plugin for tests...\n"

--- a/.github/ci-files/local.php
+++ b/.github/ci-files/local.php
@@ -14,4 +14,9 @@ $parameters = [
     'db_password'           => '',
     'admin_email'           => 'github-actions@mautic.org',
     'admin_password'        => 'mautic',
+    'mailer_from_name'      => 'GitHub Actions',
+    'mailer_from_email'     => 'github-actions@mautic.org',
+    'mailer_transport'      => 'smtp',
+    'mailer_host'           => 'localhost',
+    'mailer_port'           => '1025',
 ];

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -100,9 +100,7 @@ jobs:
       run: |
         composer install --prefer-dist --no-progress
         cp $GITHUB_WORKSPACE/.github/ci-files/local.php ./app/config/local.php
-        php bin/console mautic:install http://localhost/ \
-          --force --mailer_from_name="GitHub Actions" --mailer_from_email="github-actions@mautic.org" \
-          --mailer_transport="smtp" --mailer_host="localhost" --mailer_port="1025" --env=dev
+        php bin/console mautic:install http://localhost/ --force --env=dev
         php bin/console cache:warmup --no-interaction --env=dev
       working-directory: /var/www/html/
 


### PR DESCRIPTION
As the e-mail step was removed from mautic/mautic (see https://github.com/mautic/mautic/pull/12216), the tests need to be adapted in this repo, to be able to install Mautic correctly.

This PR addresses this