### PR TITLE
bump memory limit to ensure Mautic in dev mode can handle it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,7 @@ jobs:
         sudo a2enmod rewrite
         sudo sed -i 's,^session.save_handler =.*$,session.save_handler = redis,' /etc/php/8.0/apache2/php.ini
         sudo sed -i 's,^;session.save_path =.*$,session.save_path = "tcp://127.0.0.1:6379",' /etc/php/8.0/apache2/php.ini
+        sudo sed -i 's,^memory_limit =.*$,memory_limit = 256M,' /etc/php/8.0/apache2/php.ini
         sudo service apache2 restart
         cat /etc/php/8.0/apache2/php.ini | grep session
 


### PR DESCRIPTION
see https://github.com/mautic/mautic/pull/12213#issuecomment-1512692220

this is most likely related tot the default `memory_limit` of 128M, which is not enough for the standard apache install.

This PR is a mitigation: the proper solution I'm working on is in https://github.com/mautic/api-library/pull/290


I also pushed this PR, so we can test it against the Symfony 5 PR, see the workflow: https://github.com/mautic/api-library/actions/runs/4740330977

both the workflow from this PR as the extra workflow should succeed before merging this