### PR TITLE
Fix getMauticVersion() accessing lower-case headers as array-key

### DIFF
--- a/lib/Api/Api.php
+++ b/lib/Api/Api.php
@@ -332,10 +332,10 @@ class Api implements LoggerAwareInterface
      */
     public function getMauticVersion()
     {
-        $headers = $this->auth->getResponseHeaders();
+        $headers = array_change_key_case($this->auth->getResponseHeaders(), CASE_LOWER);
 
-        if (isset($headers['Mautic-Version'])) {
-            return $headers['Mautic-Version'];
+        if (isset($headers['mautic-version'])) {
+            return $headers['mautic-version'];
         }
 
         return null;


### PR DESCRIPTION
Fixes https://github.com/mautic/api-library/issues/233

Ensures that the mautic-version header key is always converted to lowercase prior to checking if it exists. This makes the getMauticVersion() command less error-prone, e.g. if Nginx is used as reverse-proxy which convertes HTTP headers to lower-case.