### PR TITLE
switch to dsn mailer config to ensure mail tests succeed

### DIFF
--- a/.github/ci-files/local.php
+++ b/.github/ci-files/local.php
@@ -17,6 +17,5 @@ $parameters = [
     'mailer_from_name'      => 'GitHub Actions',
     'mailer_from_email'     => 'github-actions@mautic.org',
     'mailer_transport'      => 'smtp',
-    'mailer_host'           => 'localhost',
-    'mailer_port'           => '1025',
+    'mailer_dsn'            => 'smtp://localhost:1025',
 ];


### PR DESCRIPTION
Since the recent mailer / messenger changes in Mautic, the api library tests are broken.

This PR addresses the failures, by switching the Mautic config to the new DSN style.