### PR TITLE
Replace setLogger with built in trait

### DIFF
--- a/lib/Api/Api.php
+++ b/lib/Api/Api.php
@@ -14,6 +14,7 @@ use Mautic\Auth\ApiAuth;
 use Mautic\Auth\AuthInterface;
 use Mautic\QueryBuilder\QueryBuilder;
 use Psr\Log\LoggerAwareInterface;
+use Psr\Log\LoggerAwareTrait;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -22,6 +23,8 @@ use Psr\Log\NullLogger;
  */
 class Api implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+    
     /**
      * Used by unit testing to force use of BC endpoints.
      *
@@ -91,11 +94,6 @@ class Api implements LoggerAwareInterface
     private $auth;
 
     /**
-     * @var LoggerInterface
-     */
-    private $logger;
-
-    /**
      * @param string $baseUrl
      */
     public function __construct(AuthInterface $auth, $baseUrl = '')
@@ -117,14 +115,6 @@ class Api implements LoggerAwareInterface
         }
 
         return $this->logger;
-    }
-
-    /**
-     * Sets a logger.
-     */
-    public function setLogger(LoggerInterface $logger): void
-    {
-        $this->logger = $logger;
     }
 
     /**


### PR DESCRIPTION
For my mautic API integration I can't use repositories in composer. 

I Found a better way for backwards compatibility. Just use the built-in trait.

Kind regards
moori