### PR TITLE
Adapt tests to changes in mautic/mautic#12813

### DIFF
--- a/tests/Api/FormsTest.php
+++ b/tests/Api/FormsTest.php
@@ -37,6 +37,7 @@ class FormsTest extends MauticApiTestCase
                     ],
                 ],
             ],
+            'postAction'  => 'return',
         ];
     }
 


### PR DESCRIPTION
In https://github.com/mautic/mautic/pull/12813 some logic changed, and it is now required to pass the `PostAction` in the payload of `form` API calls.

IMO this is a breaking change, and the default on the Mautic should change to something that is compatible with the previous flow.

If we want to change that default, it needs to be done in M6.
This PR is purely meant to show where the issue with the tests is located, not to be merged.