### PR TITLE
add the correct command for the test script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "guzzlehttp/guzzle": "A popular HTTP client that implements psr/http-client-implementation."
   },
   "scripts": {
-    "test": "vendor/bin/paratest"
+    "test": "vendor/bin/phpunit"
   },
   "config": {
     "allow-plugins": {


### PR DESCRIPTION
in #311 `paratest` was removed, and `phpunit` was used instead, but the composer script was not adapted.

This PR fixes this.

To test, check if `composer test` actually starts running tests (regardless if they fail or not)