### PR TITLE
An empty DEC filter shouldn't have any value. It will be null-ed in the response

### DIFF
--- a/tests/Api/EmailsTest.php
+++ b/tests/Api/EmailsTest.php
@@ -48,7 +48,7 @@ class EmailsTest extends MauticApiTestCase
                                     'field'    => 'email',
                                     'object'   => 'lead',
                                     'type'     => 'email',
-                                    'filter'   => 'Prague',
+                                    'filter'   => null,
                                     'display'  => null,
                                     'operator' => '!empty',
                                 ],


### PR DESCRIPTION
See the reasoning behind this change at https://github.com/mautic/mautic/pull/13697