### PR TITLE
Run tests on PHP 8.1 as Mautci 5.2 dropps support for 8.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.0
+        php-version: 8.1
         ini-values: session.save_handler=redis, session.save_path="tcp://127.0.0.1:6379"
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
         coverage: pcov
@@ -63,13 +63,13 @@ jobs:
       run: |
         sudo add-apt-repository ppa:ondrej/php -y
         sudo apt-get update
-        sudo apt-get install apache2 libapache2-mod-php8.0
+        sudo apt-get install apache2 libapache2-mod-php8.1
         sudo a2enmod rewrite
-        sudo sed -i 's,^session.save_handler =.*$,session.save_handler = redis,' /etc/php/8.0/apache2/php.ini
-        sudo sed -i 's,^;session.save_path =.*$,session.save_path = "tcp://127.0.0.1:6379",' /etc/php/8.0/apache2/php.ini
-        sudo sed -i 's,^memory_limit =.*$,memory_limit = 256M,' /etc/php/8.0/apache2/php.ini
+        sudo sed -i 's,^session.save_handler =.*$,session.save_handler = redis,' /etc/php/8.1/apache2/php.ini
+        sudo sed -i 's,^;session.save_path =.*$,session.save_path = "tcp://127.0.0.1:6379",' /etc/php/8.1/apache2/php.ini
+        sudo sed -i 's,^memory_limit =.*$,memory_limit = 256M,' /etc/php/8.1/apache2/php.ini
         sudo service apache2 restart
-        cat /etc/php/8.0/apache2/php.ini | grep session
+        cat /etc/php/8.1/apache2/php.ini | grep session
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
At some point we should use DDEV env for running Mautic so the 2 repos are independent.