### PR TITLE
Add release notes template

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+changelog:
+  exclude:
+    labels:
+      - chore
+    authors:
+      - github-actions
+  categories:
+    - title: ⚠️ Breaking Changes 
+      labels:
+        - bc-break
+    - title: 🔧 Refactoring 
+      labels:
+        - refactoring
+    - title: 🔒 Security
+      labels:
+        - security
+    - title: ✨ Features and enhancements
+      labels:
+        - feature
+        - enhancement
+    - title: 🐛 Bugs
+      labels:
+        - bug
+        - regression
+    - title: 🤖 Devops
+      labels:
+        - chore
+        - devops


### PR DESCRIPTION
This PR adds a release notes template which will make it easier to format changelogs when we run a release.

It requires the following labels, so we'll need to get into the habit of labelling PRs like we do in mautic/mautic:

- bc-break
- refactoring 
- security 
- feature
- enhancement
- bug
- regression
- chore
- devops