### PR TITLE
Bumping PHP from 8.1 to 8.3 in the CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.1
+        php-version: 8.3
         ini-values: session.save_handler=redis, session.save_path="tcp://127.0.0.1:6379"
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
         coverage: pcov
@@ -63,13 +63,13 @@ jobs:
       run: |
         sudo add-apt-repository ppa:ondrej/php -y
         sudo apt-get update
-        sudo apt-get install apache2 libapache2-mod-php8.1
+        sudo apt-get install apache2 libapache2-mod-php8.3
         sudo a2enmod rewrite
-        sudo sed -i 's,^session.save_handler =.*$,session.save_handler = redis,' /etc/php/8.1/apache2/php.ini
-        sudo sed -i 's,^;session.save_path =.*$,session.save_path = "tcp://127.0.0.1:6379",' /etc/php/8.1/apache2/php.ini
-        sudo sed -i 's,^memory_limit =.*$,memory_limit = 256M,' /etc/php/8.1/apache2/php.ini
+        sudo sed -i 's,^session.save_handler =.*$,session.save_handler = redis,' /etc/php/8.3/apache2/php.ini
+        sudo sed -i 's,^;session.save_path =.*$,session.save_path = "tcp://127.0.0.1:6379",' /etc/php/8.3/apache2/php.ini
+        sudo sed -i 's,^memory_limit =.*$,memory_limit = 256M,' /etc/php/8.3/apache2/php.ini
         sudo service apache2 restart
-        cat /etc/php/8.1/apache2/php.ini | grep session
+        cat /etc/php/8.3/apache2/php.ini | grep session
 
     - name: Install dependencies
       run: |
@@ -159,7 +159,7 @@ jobs:
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.1
+        php-version: 8.3
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
 
     - name: Install dependencies

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   },
   "require-dev": {
     "kint-php/kint": "^4.1",
-    "friendsofphp/php-cs-fixer": "~3.12.0",
+    "friendsofphp/php-cs-fixer": "^3.73",
     "phpunit/phpunit": "~9.5.0",
     "guzzlehttp/guzzle": "^7.5",
     "phpstan/phpstan": "^1.11"

--- a/lib/Api/Api.php
+++ b/lib/Api/Api.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -230,12 +231,12 @@ class Api implements LoggerAwareInterface
 
             if (false === strpos($url, 'http')) {
                 $error = [
-                'code'    => 500,
-                'message' => sprintf(
-                    'URL is incomplete.  Please use %s, set the base URL as the third argument to $MauticApi->newApi(), or make $endpoint a complete URL.',
-                    __CLASS__.'setBaseUrl()'
-                ),
-            ];
+                    'code'    => 500,
+                    'message' => sprintf(
+                        'URL is incomplete.  Please use %s, set the base URL as the third argument to $MauticApi->newApi(), or make $endpoint a complete URL.',
+                        __CLASS__.'setBaseUrl()'
+                    ),
+                ];
             } else {
                 try {
                     $settings = [];
@@ -251,24 +252,24 @@ class Api implements LoggerAwareInterface
 
                         // assume an error
                         $error = [
-                        'code'    => 500,
-                        'message' => $response,
-                    ];
+                            'code'    => 500,
+                            'message' => $response,
+                        ];
                     }
                 } catch (\Exception $e) {
                     $this->getLogger()->error('Failed connecting to Mautic API: '.$e->getMessage(), ['trace' => $e->getTraceAsString()]);
 
                     $error = [
-                    'code'    => $e->getCode(),
-                    'message' => $e->getMessage(),
-                ];
+                        'code'    => $e->getCode(),
+                        'message' => $e->getMessage(),
+                    ];
                 }
             }
 
             if (!empty($error)) {
                 return [
-                'errors' => [$error],
-            ];
+                    'errors' => [$error],
+                ];
             } elseif (!empty($response['errors'])) {
                 $this->getLogger()->error('Mautic API returned errors: '.var_export($response['errors'], true));
             }

--- a/lib/Api/Assets.php
+++ b/lib/Api/Assets.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,24 +16,12 @@ namespace Mautic\Api;
  */
 class Assets extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'assets';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'assets';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'asset';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:published',

--- a/lib/Api/CampaignEvents.php
+++ b/lib/Api/CampaignEvents.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2016 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,19 +16,10 @@ namespace Mautic\Api;
  */
 class CampaignEvents extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'campaigns/events';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'events';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'event';
 
     /**

--- a/lib/Api/Campaigns.php
+++ b/lib/Api/Campaigns.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,19 +16,10 @@ namespace Mautic\Api;
  */
 class Campaigns extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'campaigns';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'campaigns';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'campaign';
 
     /**
@@ -38,9 +30,6 @@ class Campaigns extends Api
         'campaigns/(.*?)/contact/(.*?)/remove' => 'campaigns/$1/contact/remove/$2', // 2.6.0
     ];
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:published',

--- a/lib/Api/Categories.php
+++ b/lib/Api/Categories.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,24 +16,12 @@ namespace Mautic\Api;
  */
 class Categories extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'categories';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'categories';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'category';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:published',

--- a/lib/Api/Companies.php
+++ b/lib/Api/Companies.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,19 +16,10 @@ namespace Mautic\Api;
  */
 class Companies extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'companies';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'companies';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'company';
 
     /**
@@ -38,9 +30,6 @@ class Companies extends Api
         'companies/(.*?)/contact/(.*?)/remove' => 'companies/$1/contact/remove/$2', // 2.6.0
     ];
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:mine',

--- a/lib/Api/CompanyFields.php
+++ b/lib/Api/CompanyFields.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,18 +16,9 @@ namespace Mautic\Api;
  */
 class CompanyFields extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'fields/company';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'fields';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'field';
 }

--- a/lib/Api/ContactFields.php
+++ b/lib/Api/ContactFields.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,18 +16,9 @@ namespace Mautic\Api;
  */
 class ContactFields extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'fields/contact';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'fields';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'field';
 }

--- a/lib/Api/Contacts.php
+++ b/lib/Api/Contacts.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -30,19 +31,10 @@ class Contacts extends Api
      */
     public const MANUAL = 3;
 
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'contacts';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'contacts';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'contact';
 
     /**
@@ -53,9 +45,6 @@ class Contacts extends Api
         'contacts/(.*?)/dnc/(.*?)/remove' => 'contacts/$1/dnc/remove/$2', // 2.6.0
     ];
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:anonymous',
@@ -121,13 +110,11 @@ class Contacts extends Api
     /**
      * Get a list of contact activity events for all contacts.
      *
-     * @param int       $id         Contact ID
-     * @param string    $search
-     * @param string    $orderBy
-     * @param string    $orderByDir
-     * @param int       $page
-     * @param \DateTime $dateFrom
-     * @param \DateTime $dateTo
+     * @param int    $id         Contact ID
+     * @param string $search
+     * @param string $orderBy
+     * @param string $orderByDir
+     * @param int    $page
      *
      * @return array|mixed
      */
@@ -139,8 +126,8 @@ class Contacts extends Api
         $orderBy = '',
         $orderByDir = 'ASC',
         $page = 1,
-        \DateTime $dateFrom = null,
-        \DateTime $dateTo = null
+        ?\DateTime $dateFrom = null,
+        ?\DateTime $dateTo = null,
     ) {
         return $this->fetchActivity('/'.$id.'/activity', $search, $includeEvents, $excludeEvents, $orderBy, $orderByDir, $page, $dateFrom, $dateTo);
     }
@@ -149,12 +136,10 @@ class Contacts extends Api
      * Get a list of contact engagement events.
      * Not related to a specific contact ID.
      *
-     * @param string    $search
-     * @param string    $orderBy
-     * @param string    $orderByDir
-     * @param int       $page
-     * @param \DateTime $dateFrom
-     * @param \DateTime $dateTo
+     * @param string $search
+     * @param string $orderBy
+     * @param string $orderByDir
+     * @param int    $page
      *
      * @return array|mixed
      */
@@ -165,8 +150,8 @@ class Contacts extends Api
         $orderBy = '',
         $orderByDir = 'ASC',
         $page = 1,
-        \DateTime $dateFrom = null,
-        \DateTime $dateTo = null
+        ?\DateTime $dateFrom = null,
+        ?\DateTime $dateTo = null,
     ) {
         return $this->fetchActivity('/activity', $search, $includeEvents, $excludeEvents, $orderBy, $orderByDir, $page, $dateFrom, $dateTo);
     }
@@ -174,13 +159,11 @@ class Contacts extends Api
     /**
      * Get a list of contact activity events for all contacts.
      *
-     * @param string    $path       of the URL after the endpoint
-     * @param string    $search
-     * @param string    $orderBy
-     * @param string    $orderByDir
-     * @param int       $page
-     * @param \DateTime $dateFrom
-     * @param \DateTime $dateTo
+     * @param string $path       of the URL after the endpoint
+     * @param string $search
+     * @param string $orderBy
+     * @param string $orderByDir
+     * @param int    $page
      *
      * @return array|mixed
      */
@@ -192,8 +175,8 @@ class Contacts extends Api
         $orderBy = '',
         $orderByDir = 'ASC',
         $page = 1,
-        \DateTime $dateFrom = null,
-        \DateTime $dateTo = null
+        ?\DateTime $dateFrom = null,
+        ?\DateTime $dateTo = null,
     ) {
         $parameters = [
             'filters' => [
@@ -315,8 +298,6 @@ class Contacts extends Api
      * @param int   $id
      * @param int   $points
      * @param array $parameters 'eventName' and 'actionName'
-     *
-     * @return mixed
      */
     public function addPoints($id, $points, array $parameters = [])
     {
@@ -329,8 +310,6 @@ class Contacts extends Api
      * @param int   $id
      * @param int   $points
      * @param array $parameters 'eventName' and 'actionName'
-     *
-     * @return mixed
      */
     public function subtractPoints($id, $points, array $parameters = [])
     {
@@ -432,8 +411,6 @@ class Contacts extends Api
      *
      * @param int    $id
      * @param string $channel
-     *
-     * @return mixed
      */
     public function removeDnc($id, $channel = 'email')
     {
@@ -449,8 +426,6 @@ class Contacts extends Api
      *
      * @param int   $id
      * @param array $utmTags
-     *
-     * @return mixed
      */
     public function addUtm($id, $utmTags)
     {
@@ -466,8 +441,6 @@ class Contacts extends Api
      *
      * @param int $id
      * @param int $utmId
-     *
-     * @return mixed
      */
     public function removeUtm($id, $utmId)
     {

--- a/lib/Api/Data.php
+++ b/lib/Api/Data.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,19 +16,10 @@ namespace Mautic\Api;
  */
 class Data extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'data';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'types';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'data';
 
     /**
@@ -43,33 +35,21 @@ class Data extends Api
         return $this->makeRequest("{$this->endpoint}/$id", $options);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPublishedList($search = '', $start = 0, $limit = 0, $orderBy = '', $orderByDir = 'ASC')
     {
         return $this->actionNotSupported(__FUNCTION__);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function create(array $parameters)
     {
         return $this->actionNotSupported(__FUNCTION__);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function edit($id, array $parameters, $createIfNotExists = false)
     {
         return $this->actionNotSupported(__FUNCTION__);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function delete($id)
     {
         return $this->actionNotSupported(__FUNCTION__);

--- a/lib/Api/Devices.php
+++ b/lib/Api/Devices.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,18 +16,9 @@ namespace Mautic\Api;
  */
 class Devices extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'devices';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'devices';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'device';
 }

--- a/lib/Api/DynamicContents.php
+++ b/lib/Api/DynamicContents.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2016 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,24 +16,12 @@ namespace Mautic\Api;
  */
 class DynamicContents extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'dynamiccontents';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'dynamicContents';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'dynamicContent';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:published',

--- a/lib/Api/Emails.php
+++ b/lib/Api/Emails.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,19 +16,10 @@ namespace Mautic\Api;
  */
 class Emails extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'emails';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'emails';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'email';
 
     /**
@@ -37,9 +29,6 @@ class Emails extends Api
         'emails/(.*?)/contact/(.*?)/send' => 'emails/$1/send/contact/$2', // 2.6.0
     ];
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:published',

--- a/lib/Api/Files.php
+++ b/lib/Api/Files.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,19 +16,10 @@ namespace Mautic\Api;
  */
 class Files extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'files/images';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'files';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'file';
 
     /**
@@ -41,9 +33,6 @@ class Files extends Api
         $this->endpoint = 'files/'.$folder;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function edit($id, array $parameters, $createIfNotExists = false)
     {
         return $this->actionNotSupported('edit');
@@ -61,25 +50,16 @@ class Files extends Api
         return parent::create($parameters);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function createBatch(array $parameters)
     {
         return $this->actionNotSupported('createBatch');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function editBatch(array $parameters, $createIfNotExists = false)
     {
         return $this->actionNotSupported('editBatch');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function deleteBatch(array $ids)
     {
         return $this->actionNotSupported('deleteBatch');

--- a/lib/Api/Focus.php
+++ b/lib/Api/Focus.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * @package     Mautic
  * @copyright   2014 Mautic, NP. All rights reserved.
@@ -14,24 +15,12 @@ namespace Mautic\Api;
  */
 class Focus extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'focus';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'focus';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'focus';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:published',

--- a/lib/Api/Forms.php
+++ b/lib/Api/Forms.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,24 +16,12 @@ namespace Mautic\Api;
  */
 class Forms extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'forms';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'forms';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'form';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:published',

--- a/lib/Api/Messages.php
+++ b/lib/Api/Messages.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,18 +16,9 @@ namespace Mautic\Api;
  */
 class Messages extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'messages';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'messages';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'message';
 }

--- a/lib/Api/Notes.php
+++ b/lib/Api/Notes.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,24 +16,12 @@ namespace Mautic\Api;
  */
 class Notes extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'notes';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'notes';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'note';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
     ];

--- a/lib/Api/Notifications.php
+++ b/lib/Api/Notifications.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,24 +16,12 @@ namespace Mautic\Api;
  */
 class Notifications extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'notifications';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'notifications';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'notification';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:published',

--- a/lib/Api/Pages.php
+++ b/lib/Api/Pages.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,24 +16,12 @@ namespace Mautic\Api;
  */
 class Pages extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'pages';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'pages';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'page';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:published',

--- a/lib/Api/PointGroups.php
+++ b/lib/Api/PointGroups.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,24 +16,12 @@ namespace Mautic\Api;
  */
 class PointGroups extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'points/groups';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'pointGroups';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'pointGroup';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:published',

--- a/lib/Api/PointTriggers.php
+++ b/lib/Api/PointTriggers.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,24 +16,12 @@ namespace Mautic\Api;
  */
 class PointTriggers extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'points/triggers';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'triggers';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'trigger';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
     ];

--- a/lib/Api/Points.php
+++ b/lib/Api/Points.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,24 +16,12 @@ namespace Mautic\Api;
  */
 class Points extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'points';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'points';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'point';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
     ];

--- a/lib/Api/Reports.php
+++ b/lib/Api/Reports.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,24 +16,12 @@ namespace Mautic\Api;
  */
 class Reports extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'reports';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'reports';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'report';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:published',
@@ -57,7 +46,7 @@ class Reports extends Api
      *
      * @return array|mixed
      */
-    public function get($id, $limit = null, $page = null, \DateTime $dateFrom = null, \DateTime $dateTo = null)
+    public function get($id, $limit = null, $page = null, ?\DateTime $dateFrom = null, ?\DateTime $dateTo = null)
     {
         $options = [];
 

--- a/lib/Api/Roles.php
+++ b/lib/Api/Roles.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,24 +16,12 @@ namespace Mautic\Api;
  */
 class Roles extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'roles';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'roles';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'role';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:admin',

--- a/lib/Api/Segments.php
+++ b/lib/Api/Segments.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,19 +16,10 @@ namespace Mautic\Api;
  */
 class Segments extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'segments';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'lists';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'list';
 
     /**

--- a/lib/Api/Smses.php
+++ b/lib/Api/Smses.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,24 +16,12 @@ namespace Mautic\Api;
  */
 class Smses extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'smses';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'smses';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'sms';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:published',

--- a/lib/Api/Stages.php
+++ b/lib/Api/Stages.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,19 +16,10 @@ namespace Mautic\Api;
  */
 class Stages extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'stages';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'stages';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'stage';
 
     protected $bcRegexEndpoints = [
@@ -35,9 +27,6 @@ class Stages extends Api
         'stages/(.*?)/contact/(.*?)/remove' => 'stages/$1/contact/remove/$2', // 2.6.0
     ];
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
     ];

--- a/lib/Api/Stats.php
+++ b/lib/Api/Stats.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,14 +16,8 @@ namespace Mautic\Api;
  */
 class Stats extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'stats';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'stats';
 
     /**
@@ -53,41 +48,26 @@ class Stats extends Api
         return $this->makeRequest($endpoint, $parameters);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function delete($id)
     {
         return $this->actionNotSupported('delete');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getList($search = '', $start = 0, $limit = 0, $orderBy = '', $orderByDir = 'ASC', $publishedOnly = false, $minimal = false)
     {
         return $this->actionNotSupported('getList');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function create(array $parameters)
     {
         return $this->actionNotSupported('create');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPublishedList($search = '', $start = 0, $limit = 0, $orderBy = '', $orderByDir = 'ASC')
     {
         return $this->actionNotSupported('getPublishedList');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function edit($id, array $parameters, $createIfNotExists = false)
     {
         return $this->actionNotSupported('edit');

--- a/lib/Api/Tags.php
+++ b/lib/Api/Tags.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,18 +16,9 @@ namespace Mautic\Api;
  */
 class Tags extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'tags';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'tags';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'tag';
 }

--- a/lib/Api/Themes.php
+++ b/lib/Api/Themes.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,26 +16,14 @@ namespace Mautic\Api;
  */
 class Themes extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'themes';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'themes';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'theme';
 
-    protected $temporaryFilePath = null;
+    protected $temporaryFilePath;
 
-    /**
-     * {@inheritdoc}
-     */
     public function edit($id, array $parameters, $createIfNotExists = false)
     {
         return $this->actionNotSupported('edit');
@@ -52,25 +41,16 @@ class Themes extends Api
         return parent::create($parameters);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function createBatch(array $parameters)
     {
         return $this->actionNotSupported('createBatch');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function editBatch(array $parameters, $createIfNotExists = false)
     {
         return $this->actionNotSupported('editBatch');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function deleteBatch(array $ids)
     {
         return $this->actionNotSupported('deleteBatch');

--- a/lib/Api/Tweets.php
+++ b/lib/Api/Tweets.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,23 +16,11 @@ namespace Mautic\Api;
  */
 class Tweets extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'tweets';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'tweets';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'tweet';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [];
 }

--- a/lib/Api/Users.php
+++ b/lib/Api/Users.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,24 +16,12 @@ namespace Mautic\Api;
  */
 class Users extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'users';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'users';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'user';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:admin',

--- a/lib/Api/Webhooks.php
+++ b/lib/Api/Webhooks.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -15,24 +16,12 @@ namespace Mautic\Api;
  */
 class Webhooks extends Api
 {
-    /**
-     * {@inheritdoc}
-     */
     protected $endpoint = 'hooks';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $listName = 'hooks';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $itemName = 'hook';
 
-    /**
-     * {@inheritdoc}
-     */
     protected $searchCommands = [
         'ids',
         'is:published',

--- a/lib/Auth/AbstractAuth.php
+++ b/lib/Auth/AbstractAuth.php
@@ -44,8 +44,6 @@ abstract class AbstractAuth implements AuthInterface
     /**
      * @param string $url
      * @param string $method
-     *
-     * @return mixed
      */
     abstract protected function prepareRequest($url, array $headers, array $parameters, $method, array $settings);
 
@@ -89,7 +87,7 @@ abstract class AbstractAuth implements AuthInterface
     /**
      * Returns the HTTP response.
      *
-     * @return \Psr\Http\Message\ResponseInterface
+     * @return ResponseInterface
      */
     public function getResponse()
     {
@@ -97,8 +95,6 @@ abstract class AbstractAuth implements AuthInterface
     }
 
     /**
-     * {@inheritdoc}
-     *
      * @throws UnexpectedResponseFormatException|Exception
      */
     public function makeRequest($url, array $parameters = [], $method = 'GET', array $settings = [])

--- a/lib/Auth/ApiAuth.php
+++ b/lib/Auth/ApiAuth.php
@@ -21,7 +21,7 @@ class ApiAuth
 {
     protected ClientInterface $client;
 
-    public function __construct(ClientInterface $client = null)
+    public function __construct(?ClientInterface $client = null)
     {
         $this->client = $client ?: Psr18ClientDiscovery::find();
     }

--- a/lib/Auth/BasicAuth.php
+++ b/lib/Auth/BasicAuth.php
@@ -74,9 +74,6 @@ class BasicAuth extends AbstractAuth
      */
     private $userName;
 
-    /**
-     * {@inheritdoc}
-     */
     public function isAuthorized()
     {
         return !empty($this->userName) && !empty($this->password);

--- a/lib/Auth/OAuth.php
+++ b/lib/Auth/OAuth.php
@@ -155,9 +155,6 @@ class OAuth extends AbstractAuth
         ];
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isAuthorized()
     {
         // Check for existing access token
@@ -290,7 +287,7 @@ class OAuth extends AbstractAuth
         $accessTokenExpires = null,
         $callback = null,
         $scope = null,
-        $refreshToken = null
+        $refreshToken = null,
     ) {
         $this->_client_id           = $clientKey;
         $this->_client_secret       = $clientSecret;

--- a/lib/Exception/AbstractApiException.php
+++ b/lib/Exception/AbstractApiException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -21,10 +22,7 @@ abstract class AbstractApiException extends \Exception
      */
     public const DEFAULT_MESSAGE = 'Unknown Error';
 
-    /**
-     * {@inheritdoc}
-     */
-    public function __construct($message = '', $code = 500, \Exception $previous = null)
+    public function __construct($message = '', $code = 500, ?\Exception $previous = null)
     {
         if (empty($message)) {
             // Use message appropriate to the subclass with late binding

--- a/lib/Exception/ActionNotSupportedException.php
+++ b/lib/Exception/ActionNotSupportedException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/lib/Exception/AuthorizationRequiredException.php
+++ b/lib/Exception/AuthorizationRequiredException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -21,9 +22,8 @@ class AuthorizationRequiredException extends \Exception
      * AuthorizationRequiredException constructor.
      *
      * @param string $authUrl
-     *                        {@inheritdoc}
      */
-    public function __construct($authUrl, $message = 'Authorization is required.', $code = 401, \Exception $previous = null)
+    public function __construct($authUrl, $message = 'Authorization is required.', $code = 401, ?\Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->authUrl = $authUrl;

--- a/lib/Exception/ContextNotFoundException.php
+++ b/lib/Exception/ContextNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/lib/Exception/IncorrectParametersReturnedException.php
+++ b/lib/Exception/IncorrectParametersReturnedException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/lib/Exception/RequiredParameterMissingException.php
+++ b/lib/Exception/RequiredParameterMissingException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/lib/Exception/UnexpectedResponseFormatException.php
+++ b/lib/Exception/UnexpectedResponseFormatException.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -27,10 +28,7 @@ class UnexpectedResponseFormatException extends AbstractApiException
      */
     private $response;
 
-    /**
-     * {@inheritdoc}
-     */
-    public function __construct(Response $response, $message = '', $code = 500, \Exception $previous = null)
+    public function __construct(Response $response, $message = '', $code = 500, ?\Exception $previous = null)
     {
         $this->response = $response;
 

--- a/lib/MauticApi.php
+++ b/lib/MauticApi.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/lib/QueryBuilder/QueryBuilder.php
+++ b/lib/QueryBuilder/QueryBuilder.php
@@ -53,10 +53,7 @@ class QueryBuilder
         ];
     }
 
-    /**
-     * @param WhereBuilder $whereBuilder
-     */
-    public function addWhere(WhereBuilder $whereBuilder = null)
+    public function addWhere(?WhereBuilder $whereBuilder = null)
     {
         if (null === $whereBuilder) {
             if (null === self::$whereBuilder) {

--- a/lib/QueryBuilder/WhereBuilder.php
+++ b/lib/QueryBuilder/WhereBuilder.php
@@ -24,7 +24,7 @@ class WhereBuilder
     /**
      * @var null
      */
-    protected $composite = null;
+    protected $composite;
 
     /**
      * WhereBuilder constructor.
@@ -46,7 +46,6 @@ class WhereBuilder
 
     /**
      * @param string $col
-     * @param mixed  $val
      *
      * @return $this
      */
@@ -59,7 +58,6 @@ class WhereBuilder
 
     /**
      * @param string $col
-     * @param mixed  $val
      *
      * @return $this
      */
@@ -72,7 +70,6 @@ class WhereBuilder
 
     /**
      * @param string $col
-     * @param mixed  $val
      *
      * @return $this
      */
@@ -85,7 +82,6 @@ class WhereBuilder
 
     /**
      * @param string $col
-     * @param mixed  $val
      *
      * @return $this
      */
@@ -98,7 +94,6 @@ class WhereBuilder
 
     /**
      * @param string $col
-     * @param mixed  $val
      *
      * @return $this
      */
@@ -111,7 +106,6 @@ class WhereBuilder
 
     /**
      * @param string $col
-     * @param mixed  $val
      *
      * @return $this
      */
@@ -124,7 +118,6 @@ class WhereBuilder
 
     /**
      * @param string $col
-     * @param mixed  $val
      *
      * @return $this
      */
@@ -137,7 +130,6 @@ class WhereBuilder
 
     /**
      * @param string $col
-     * @param mixed  $val
      *
      * @return $this
      */
@@ -174,8 +166,6 @@ class WhereBuilder
 
     /**
      * @param string $col
-     * @param mixed  $val1
-     * @param mixed  $val2
      *
      * @return $this
      */
@@ -188,8 +178,6 @@ class WhereBuilder
 
     /**
      * @param string $col
-     * @param mixed  $val1
-     * @param mixed  $val2
      *
      * @return $this
      */

--- a/lib/Response.php
+++ b/lib/Response.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -19,7 +20,7 @@ use Psr\Http\Message\ResponseInterface;
 class Response
 {
     /**
-     * @var \Psr\Http\Message\ResponseInterface
+     * @var ResponseInterface
      */
     private $response;
 

--- a/tests/Api/AssetsTest.php
+++ b/tests/Api/AssetsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/Auth/AbstractAuthTest.php
+++ b/tests/Api/Auth/AbstractAuthTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/Auth/BasicAuthTest.php
+++ b/tests/Api/Auth/BasicAuthTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/CampaignsTest.php
+++ b/tests/Api/CampaignsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/CategoriesTest.php
+++ b/tests/Api/CategoriesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/CompaniesTest.php
+++ b/tests/Api/CompaniesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/CompanyFieldTest.php
+++ b/tests/Api/CompanyFieldTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/ContactFieldsTest.php
+++ b/tests/Api/ContactFieldsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/ContactsTest.php
+++ b/tests/Api/ContactsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/DataTest.php
+++ b/tests/Api/DataTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -18,17 +19,17 @@ class DataTest extends MauticApiTestCase
     protected $dataToTest = [
         'Core Widgets' => [
             'recent.activity'                => 'Recent Activity',
-            ],
+        ],
         'Asset Widgets' => [
             'asset.downloads.in.time'        => 'Downloads in time',
             'unique.vs.repetitive.downloads' => 'Unique vs repetitive downloads',
             'popular.assets'                 => 'Popular assets',
             'created.assets'                 => 'Created assets',
-            ],
+        ],
         'Campaign Widgets' => [
             'events.in.time'                 => 'Events triggered in time',
             'leads.added.in.time'            => 'Leads added in time',
-            ],
+        ],
         'Email Widgets' => [
             'emails.in.time'                 => 'Emails in time',
             'ignored.vs.read.emails'         => 'Ignored vs read',
@@ -37,13 +38,13 @@ class DataTest extends MauticApiTestCase
             'most.read.emails'               => 'Most read emails',
             'created.emails'                 => 'Created emails',
             'device.granularity.email'       => 'Devices for emails read',
-            ],
+        ],
         'Form Widgets' => [
             'submissions.in.time'            => 'Submissions in time',
             'top.submission.referrers'       => 'Top submission referrers',
             'top.submitters'                 => 'Top submitters',
             'created.forms'                  => 'Created forms',
-            ],
+        ],
         'Contact Widgets' => [
             'created.leads.in.time'          => 'Created contacts in time',
             'anonymous.vs.identified.leads'  => 'Anonymous vs identified contacts',
@@ -122,7 +123,7 @@ class DataTest extends MauticApiTestCase
             'create'            => function () { return $this->api->create([]); },
             'edit'              => function () { return $this->api->edit('x', []); },
             'delete'            => function () { return $this->api->delete('x'); },
-            ];
+        ];
         foreach ($notSupported as $key => $closure) {
             $response = $closure();
             $this->assertTrue(!empty($response['errors']), 'Should contain Error element');

--- a/tests/Api/DevicesTest.php
+++ b/tests/Api/DevicesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/DynamicContentsTest.php
+++ b/tests/Api/DynamicContentsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/EmailsTest.php
+++ b/tests/Api/EmailsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/ExceptionsTest.php
+++ b/tests/Api/ExceptionsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/FilesTest.php
+++ b/tests/Api/FilesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/FocusTest.php
+++ b/tests/Api/FocusTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -26,17 +27,17 @@ class FocusTest extends MauticApiTestCase
             'html'       => '<div><strong style="color:red">html mode enabled</strong></div>',
             'properties' => [
                 'bar' => [
-                        'allow_hide' => 1,
-                        'sticky'     => 1,
-                        'size'       => 'large',
-                        'placement'  => 'top',
-                    ],
+                    'allow_hide' => 1,
+                    'sticky'     => 1,
+                    'size'       => 'large',
+                    'placement'  => 'top',
+                ],
                 'modal' => [
-                        'placement' => 'top',
-                    ],
+                    'placement' => 'top',
+                ],
                 'notification' => [
-                        'placement' => 'top_left',
-                    ],
+                    'placement' => 'top_left',
+                ],
                 'animate'         => 1,
                 'link_activation' => 1,
                 'colors'          => [

--- a/tests/Api/FormsTest.php
+++ b/tests/Api/FormsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/MauticApiTestCase.php
+++ b/tests/Api/MauticApiTestCase.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic
@@ -18,11 +19,11 @@ use PHPUnit\Framework\TestCase;
 
 abstract class MauticApiTestCase extends TestCase
 {
-    protected $config               = null;
+    protected $config;
     protected $skipPayloadAssertion = [];
     protected $testPayload          = [];
 
-    protected $mauticVersion = null;
+    protected $mauticVersion;
 
     /** @var Api */
     protected $api;
@@ -102,7 +103,7 @@ abstract class MauticApiTestCase extends TestCase
         array $payload = [],
         $isBatch = false,
         $idColumn = 'id',
-        $callback = null
+        $callback = null,
     ) {
         $this->assertErrors($response);
 
@@ -229,7 +230,7 @@ abstract class MauticApiTestCase extends TestCase
         }
     }
 
-    protected function standardTestCreateGetAndDelete(array $payload = null)
+    protected function standardTestCreateGetAndDelete(?array $payload = null)
     {
         if (empty($payload)) {
             $payload = $this->testPayload;
@@ -250,7 +251,7 @@ abstract class MauticApiTestCase extends TestCase
         $this->assertErrors($response);
     }
 
-    protected function standardTestBatchEndpoints(array $batch = null, $callback = null)
+    protected function standardTestBatchEndpoints(?array $batch = null, $callback = null)
     {
         if (method_exists($this, 'setUpPayloadClass')) {
             $this->setUpPayloadClass();

--- a/tests/Api/MessagesTest.php
+++ b/tests/Api/MessagesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/NotesTest.php
+++ b/tests/Api/NotesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/NotificationsTest.php
+++ b/tests/Api/NotificationsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/PagesTest.php
+++ b/tests/Api/PagesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/PointTriggersTest.php
+++ b/tests/Api/PointTriggersTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/PointsTest.php
+++ b/tests/Api/PointsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/ReportsTest.php
+++ b/tests/Api/ReportsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/ResponseInfoTest.php
+++ b/tests/Api/ResponseInfoTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/RolesTest.php
+++ b/tests/Api/RolesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/SegmentsTest.php
+++ b/tests/Api/SegmentsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/SmsesTest.php
+++ b/tests/Api/SmsesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/StagesTest.php
+++ b/tests/Api/StagesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/StatsTest.php
+++ b/tests/Api/StatsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/TagsTest.php
+++ b/tests/Api/TagsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/ThemesTest.php
+++ b/tests/Api/ThemesTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/TweetsTest.php
+++ b/tests/Api/TweetsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/UsersTest.php
+++ b/tests/Api/UsersTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/UtmTagsTest.php
+++ b/tests/Api/UtmTagsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/Api/WebhooksTest.php
+++ b/tests/Api/WebhooksTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic

--- a/tests/ResponseTest.php
+++ b/tests/ResponseTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @copyright   2014 Mautic, NP. All rights reserved.
  * @author      Mautic


### PR DESCRIPTION
Since we've updated the main branch in the https://github.com/mautic/mautic repo from 6.x to 7.x we also have to upgrade the PHP version that is running the CI tests. Symfony 7 supports PHP 8.2+. I'm changing it to PHP 8.3 already so we don't have to change it again in the near future.

The PHP bump required the PHP CS FIXER library update as it didn't support PHP 8.2+. Then I run the `vendor/bin/php-cs-fixer fix` command to update the code style for this new version which generated most of the changes in this PR.