### PR TITLE
Bump MySQL version to 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
 
     services:
       mysql:
-        image: mysql:5.7
+        image: mysql:8.4
         env:
           MYSQL_ALLOW_EMPTY_PASSWORD: yes
           MYSQL_DATABASE: mautictest


### PR DESCRIPTION
https://github.com/mautic/api-library/commit/e968a0d51e90fb3a45652831929b90bf679f1100/checks

PHPUnit tests are failing due to an unsupported MySQL version. This PR updates the MySQL version to the minimum supported version, which is 8.4.

```
Error:   - [error] Your database version (5.7.44) is too old for Mautic to work correctly. Supported versions are MySQL 8.4.0 (or higher) and MariaDB 10.11.0 (or higher).
```