### PR TITLE
Bumping PHP to supported version from 8.0 to 8.2 + dependencies

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -172,3 +172,6 @@ jobs:
 
     - name: Run PHPSTAN tests
       run: composer phpstan
+
+    - name: Run Rector tests
+      run: vendor/bin/rector process --dry-run

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.3
+        php-version: 8.2
         ini-values: session.save_handler=redis, session.save_path="tcp://127.0.0.1:6379"
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
         coverage: pcov
@@ -159,7 +159,7 @@ jobs:
     - name: Setup PHP, with composer and extensions
       uses: shivammathur/setup-php@v2
       with:
-        php-version: 8.3
+        php-version: 8.2
         extensions: mbstring, xml, ctype, iconv, intl, pdo_sqlite, mysql, pdo_mysql
 
     - name: Install dependencies

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 # Using the Mautic API Library
 
 ## Requirements
-* PHP 8.0 or newer
+* PHP 8.2 or newer
 
 ## Installing the API Library
 You can install the API Library with the following command:

--- a/composer.json
+++ b/composer.json
@@ -27,14 +27,14 @@
     "friendsofphp/php-cs-fixer": "^3.93",
     "phpunit/phpunit": "~9.5.0",
     "guzzlehttp/guzzle": "^7.5",
-    "phpstan/phpstan": "^1.11"
+    "phpstan/phpstan": "^2.1"
   },
   "suggest": {
     "guzzlehttp/guzzle": "A popular HTTP client that implements psr/http-client-implementation."
   },
   "scripts": {
     "test": "vendor/bin/phpunit",
-    "phpstan": "vendor/bin/phpstan analyse"
+    "phpstan": "php -d memory_limit=1G vendor/bin/phpstan analyse"
   },
   "config": {
     "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "friendsofphp/php-cs-fixer": "^3.93",
     "phpunit/phpunit": "~9.5.0",
     "guzzlehttp/guzzle": "^7.5",
-    "phpstan/phpstan": "^2.1"
+    "phpstan/phpstan": "^2.1",
+    "rector/rector": "^2.3"
   },
   "suggest": {
     "guzzlehttp/guzzle": "A popular HTTP client that implements psr/http-client-implementation."

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   },
   "require": {
-    "php": ">=8.0",
+    "php": ">=8.2",
     "ext-json": "*",
     "psr/log": "~1.0 || ~2.0 || ~3.0",
     "psr/http-client": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   },
   "require-dev": {
     "kint-php/kint": "^4.1",
-    "friendsofphp/php-cs-fixer": "^3.73",
+    "friendsofphp/php-cs-fixer": "^3.93",
     "phpunit/phpunit": "~9.5.0",
     "guzzlehttp/guzzle": "^7.5",
     "phpstan/phpstan": "^1.11"

--- a/lib/Api/Api.php
+++ b/lib/Api/Api.php
@@ -111,7 +111,7 @@ class Api implements LoggerAwareInterface
     public function getLogger()
     {
         // If a logger hasn't been set, use NullLogger
-        if (!($this->logger instanceof LoggerInterface)) {
+        if (!$this->logger instanceof LoggerInterface) {
             $this->logger = new NullLogger();
         }
 

--- a/lib/Auth/OAuth.php
+++ b/lib/Auth/OAuth.php
@@ -471,9 +471,8 @@ class OAuth extends AbstractAuth
         if (!$this->_do_not_redirect) {
             header('Location: '.$authUrl);
             exit;
-        } else {
-            throw new AuthorizationRequiredException($authUrl);
         }
+        throw new AuthorizationRequiredException($authUrl);
     }
 
     /**

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/lib',
+        __DIR__ . '/tests',
+    ])
+    // uncomment to reach your current PHP version
+    // ->withPhpSets()
+    ->withTypeCoverageLevel(0)
+    ->withDeadCodeLevel(0)
+    ->withCodeQualityLevel(0);

--- a/tests/Api/CampaignsTest.php
+++ b/tests/Api/CampaignsTest.php
@@ -308,7 +308,7 @@ class CampaignsTest extends MauticApiTestCase
 
     public function testBatchEndpoints()
     {
-        $this->standardTestBatchEndpoints(null, function ($response, &$batch, $action) {
+        $this->standardTestBatchEndpoints(null, function ($response, &$batch, $action): void {
             switch ($action) {
                 case 'create':
                     foreach ($batch as &$item) {

--- a/tests/Api/ContactsTest.php
+++ b/tests/Api/ContactsTest.php
@@ -52,7 +52,7 @@ class ContactsTest extends AbstractCustomFieldsTest
         $this->assertTrue(isset($response['filters']));
 
         if ($expectedEvents) {
-            foreach ($expectedEvents as $key => $eventName) {
+            foreach ($expectedEvents as $eventName) {
                 $actual = 'oops Missing';
                 foreach ($response['events'] as $event) {
                     if ($eventName == $event['event']) {

--- a/tests/Api/FormsTest.php
+++ b/tests/Api/FormsTest.php
@@ -196,7 +196,7 @@ class FormsTest extends MauticApiTestCase
 
     public function testBatchEndpoints()
     {
-        $this->standardTestBatchEndpoints(null, function ($response, &$batch, $action) {
+        $this->standardTestBatchEndpoints(null, function ($response, &$batch, $action): void {
             switch ($action) {
                 case 'create':
                     foreach ($batch as &$item) {

--- a/tests/Api/PointTriggersTest.php
+++ b/tests/Api/PointTriggersTest.php
@@ -146,7 +146,7 @@ class PointTriggersTest extends MauticApiTestCase
 
     public function testBatchEndpoints()
     {
-        $this->standardTestBatchEndpoints(null, function ($response, &$batch, $action) {
+        $this->standardTestBatchEndpoints(null, function ($response, &$batch, $action): void {
             switch ($action) {
                 case 'create':
                     foreach ($batch as &$item) {

--- a/tests/Api/SegmentsTest.php
+++ b/tests/Api/SegmentsTest.php
@@ -161,7 +161,7 @@ class SegmentsTest extends MauticApiTestCase
 
     public function testBatchEndpoints()
     {
-        $this->standardTestBatchEndpoints(null, function ($response, &$batch, $action) {
+        $this->standardTestBatchEndpoints(null, function ($response, &$batch, $action): void {
             switch ($action) {
                 // Add extra values to the batch after create, as the API returns them in the response.
                 // This is probably related to https://github.com/mautic/mautic/pull/8649


### PR DESCRIPTION
I can see this warning in the [CI](https://github.com/mautic/api-library/actions/runs/21330775882/job/61447765850) that has now started to fail:

```
You are running PHP CS Fixer on PHP 8.3.29, but the minimum PHP version supported by your project in composer.json is PHP 8.0. Executing PHP CS Fixer on newer PHP versions may introduce syntax or features not yet available in PHP 8.0, which could cause issues under that version. It is recommended to run PHP CS Fixer on PHP 8.0, to fit your project specifics.
```

That highlights 2 issues. One is that this library is still supporting a version that is 2 years out of security updates. We should upgrade that to 8.2 which still gets security updates:

https://www.php.net/supported-versions.php

While messing with dev dependencies I increased versions for CS fixer (that allowed me to see and automatically fix the issues from the CI), PHPSTAN and added Rector with default config. Plus adding a step for CI to run it.