### PR TITLE
Fix MOTD failure in CI by forcing APP_ENV=prod during composer install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -102,7 +102,7 @@ jobs:
       env:
         DB_PORT: ${{ job.services.mysql.ports[3306] }}
       run: |
-        composer install --prefer-dist --no-progress
+        APP_ENV=prod SYMFONY_ENV=prod composer install --prefer-dist --no-progress
         if [[ "$(jq -r '.version | .[0:1]' app/release_metadata.json)" == "4" ]]; then
             cp $GITHUB_WORKSPACE/.github/ci-files/local_4.php ./app/config/local.php
             php bin/console mautic:install http://localhost/ --force --env=test --mailer_from_name="GitHub Actions" --mailer_from_email="github-actions@mautic.org"


### PR DESCRIPTION
This fixes a CI failure during `composer install` where `mautic:motd` was exiting with `MOTD response was empty`.

The issue was not the MOTD endpoint itself, but the environment the command was running in. Our CI `.env` sets `APP_ENV=test`, so when Composer runs its post-install scripts, `bin/console mautic:motd` is executed with Mautic’s test configuration. In `app/config/config_test.php`, the `http_client` service is replaced with `Symfony\Component\HttpClient\MockHttpClient`, so no real HTTP request is made and the command receives an empty response body.

The fix is to run `composer install` with `APP_ENV=prod`, so Composer lifecycle scripts execute with the normal service configuration and use the real HTTP client. The rest of the workflow (installation, cache warmup, PHPUnit) still runs explicitly with `--env=test`, so test behavior remains unchanged.