### PR TITLE
Fixing tests failing a new validation

### DIFF
--- a/tests/Api/CampaignsTest.php
+++ b/tests/Api/CampaignsTest.php
@@ -369,8 +369,6 @@ class CampaignsTest extends MauticApiTestCase
     public function testCampaignContactGetList($cleanup = true)
     {
         $this->setUpPayloadClass();
-        $response = $this->api->create($this->testPayload);
-        $this->assertPayload($response);
 
         // Create contact
         $contactsContext = $this->getContext('contacts');


### PR DESCRIPTION
The problem: The test was creating two campaigns but only deleting one. When clearPayloadItems() tried to delete the segment, it was still being used by the first (undeleted) campaign.

The fix: Removed the unnecessary first campaign creation at the start of the test. Now only one campaign is created, used, tested, and properly deleted before clearing the payload items. The segment will no longer be in use when deletion is attempted.