### PR TITLE
Using an existing remote asset

### DIFF
--- a/tests/Api/AssetsTest.php
+++ b/tests/Api/AssetsTest.php
@@ -23,7 +23,7 @@ class AssetsTest extends MauticApiTestCase
         $this->testPayload = [
             'title'           => 'Mautic Logo sent as a API request',
             'storageLocation' => 'remote',
-            'file'            => 'https://www.mautic.org/media/logos/logo/Mautic_Logo_DB.pdf',
+            'file'            => 'https://mautic.org/wp-content/uploads/2025/01/Mautic_Logo_LB.pdf',
         ];
 
         if ('4' == $this->mauticVersion) {

--- a/tests/Api/CategoriesTest.php
+++ b/tests/Api/CategoriesTest.php
@@ -50,7 +50,7 @@ class CategoriesTest extends MauticApiTestCase
         $assetPayload = [
             'title'           => 'Mautic Logo sent as a API request',
             'storageLocation' => 'remote',
-            'file'            => 'https://www.mautic.org/media/logos/logo/Mautic_Logo_DB.pdf',
+            'file'            => 'https://mautic.org/wp-content/uploads/2025/01/Mautic_Logo_LB.pdf',
             'category'        => $categoryId,
         ];
 


### PR DESCRIPTION
When we merged asset validations to Mautic: https://github.com/mautic/mautic/pull/16045

The asset related tests started to fail here. It turns out the validation failed because the remote files we were using in the tests didn't exist anymore. So the validation failed correctly. When replaced with an existing remote file the tests are passing again.