### PR TITLE
Stage weight must be unique to pass the validation

### DIFF
--- a/tests/Api/MauticApiTestCase.php
+++ b/tests/Api/MauticApiTestCase.php
@@ -310,13 +310,14 @@ abstract class MauticApiTestCase extends TestCase
 
     public function standardTestEditPatch(array $editTo)
     {
-        $response = $this->api->edit(10000, $this->getTestPayload());
+        $createPayload = $this->getTestPayload();
+        $response      = $this->api->edit(10000, $createPayload);
 
         // there should be an error as the item shouldn't exist
         $this->assertTrue(isset($response['errors'][0]), $response['errors'][0]['message']);
 
-        $response = $this->api->create($this->getTestPayload());
-        $this->assertPayload($response);
+        $response = $this->api->create($createPayload);
+        $this->assertPayload($response, $createPayload);
 
         $response = $this->api->edit($response[$this->api->itemName()]['id'], $editTo);
         $this->assertPayload($response, $editTo);
@@ -327,8 +328,9 @@ abstract class MauticApiTestCase extends TestCase
 
     public function standardTestEditPut()
     {
-        $response = $this->api->edit(10000, $this->getTestPayload(), true);
-        $this->assertPayload($response);
+        $payload  = $this->getTestPayload();
+        $response = $this->api->edit(10000, $payload, true);
+        $this->assertPayload($response, $payload);
 
         // now delete the entity
         $response = $this->api->delete($response[$this->api->itemName()]['id']);

--- a/tests/Api/MauticApiTestCase.php
+++ b/tests/Api/MauticApiTestCase.php
@@ -173,13 +173,19 @@ abstract class MauticApiTestCase extends TestCase
         }
     }
 
+    protected function getTestPayload(): array
+    {
+        return $this->testPayload;
+    }
+
     protected function standardTestGetListOfSpecificIds($callback = null)
     {
         // Create some items first
         $itemIds = [];
         for ($i = 0; $i <= 2; ++$i) {
-            $response = $this->api->create($this->testPayload);
-            $this->assertErrors($response, 'Payload: '.json_encode($this->testPayload, JSON_PRETTY_PRINT));
+            $payload  = $this->getTestPayload();
+            $response = $this->api->create($payload);
+            $this->assertErrors($response, 'Payload: '.json_encode($payload, JSON_PRETTY_PRINT));
             $itemIds[] = $response[$this->api->itemName()]['id'];
         }
 
@@ -233,7 +239,7 @@ abstract class MauticApiTestCase extends TestCase
     protected function standardTestCreateGetAndDelete(?array $payload = null)
     {
         if (empty($payload)) {
-            $payload = $this->testPayload;
+            $payload = $this->getTestPayload();
         }
 
         // Create item
@@ -259,9 +265,9 @@ abstract class MauticApiTestCase extends TestCase
 
         if (null == $batch) {
             $batch = [
-                $this->testPayload,
-                $this->testPayload,
-                $this->testPayload,
+                $this->getTestPayload(),
+                $this->getTestPayload(),
+                $this->getTestPayload(),
             ];
         }
 
@@ -304,12 +310,12 @@ abstract class MauticApiTestCase extends TestCase
 
     public function standardTestEditPatch(array $editTo)
     {
-        $response = $this->api->edit(10000, $this->testPayload);
+        $response = $this->api->edit(10000, $this->getTestPayload());
 
         // there should be an error as the item shouldn't exist
         $this->assertTrue(isset($response['errors'][0]), $response['errors'][0]['message']);
 
-        $response = $this->api->create($this->testPayload);
+        $response = $this->api->create($this->getTestPayload());
         $this->assertPayload($response);
 
         $response = $this->api->edit($response[$this->api->itemName()]['id'], $editTo);
@@ -321,7 +327,7 @@ abstract class MauticApiTestCase extends TestCase
 
     public function standardTestEditPut()
     {
-        $response = $this->api->edit(10000, $this->testPayload, true);
+        $response = $this->api->edit(10000, $this->getTestPayload(), true);
         $this->assertPayload($response);
 
         // now delete the entity

--- a/tests/Api/StagesTest.php
+++ b/tests/Api/StagesTest.php
@@ -13,11 +13,21 @@ namespace Mautic\Tests\Api;
 
 class StagesTest extends MauticApiTestCase
 {
+    private static $weightCounter = 0;
+
     public function setUp(): void
     {
         $this->api         = $this->getContext('stages');
         $this->testPayload = [
             'name' => 'test',
+        ];
+    }
+
+    protected function getTestPayload(): array
+    {
+        return [
+            'name'   => sprintf('test %s', uniqid('', true)),
+            'weight' => (int) (microtime(true) * 1000000) + ++self::$weightCounter,
         ];
     }
 
@@ -58,8 +68,9 @@ class StagesTest extends MauticApiTestCase
         $contact = $response['contact'];
 
         // Create stage
-        $response = $this->api->create($this->testPayload);
-        $this->assertPayload($response);
+        $payload  = $this->getTestPayload();
+        $response = $this->api->create($payload);
+        $this->assertPayload($response, $payload);
         $stage = $response[$this->api->itemName()];
 
         // Add contact to the stage

--- a/tests/Api/StagesTest.php
+++ b/tests/Api/StagesTest.php
@@ -13,7 +13,7 @@ namespace Mautic\Tests\Api;
 
 class StagesTest extends MauticApiTestCase
 {
-    private static $weightCounter = 0;
+    private static $nextWeight;
 
     public function setUp(): void
     {
@@ -27,8 +27,21 @@ class StagesTest extends MauticApiTestCase
     {
         return [
             'name'   => sprintf('test %s', uniqid('', true)),
-            'weight' => (int) (microtime(true) * 1000000) + ++self::$weightCounter,
+            'weight' => $this->getNextWeight(),
         ];
+    }
+
+    private function getNextWeight(): int
+    {
+        if (null === self::$nextWeight) {
+            $response   = $this->api->getList('', 0, 1, 'weight', 'DESC');
+            $firstStage = $response[$this->api->listName()][0] ?? [];
+            $maxWeight  = isset($firstStage['weight']) ? (int) $firstStage['weight'] : 0;
+
+            self::$nextWeight = $maxWeight + 1;
+        }
+
+        return self::$nextWeight++;
     }
 
     public function testGetList()


### PR DESCRIPTION
The API Library tests started to fail after a stage validation was added:
```
There were 8 failures:

1) Mautic\Tests\Api\CampaignsTest::testEditPatch
The response has unexpected status code (400).

Response: {"errors":[{"code":400,"message":"publishUp: Please enter a valid date and time.","details":{"publishUp":["Please enter a valid date and time."]}}]}

Failed asserting that false is true.

/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:93
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:108
/home/runner/work/api-library/api-library/tests/Api/CampaignsTest.php:244

2) Mautic\Tests\Api\CampaignsTest::testEventAndSourceDeleteViaPut
The response has unexpected status code (400).

Response: {"errors":[{"code":400,"message":"publishUp: Please enter a valid date and time.","details":{"publishUp":["Please enter a valid date and time."]}}]}

Failed asserting that false is true.

/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:93
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:108
/home/runner/work/api-library/api-library/tests/Api/CampaignsTest.php:349

3) Mautic\Tests\Api\StagesTest::testGetListOfSpecificIds
The response has unexpected status code (400).

Response: {"errors":[{"code":400,"message":"weight: Another stage with this weight already exists.","details":{"weight":["Another stage with this weight already exists."]}}]}
Payload: {
    "name": "test"
}
Failed asserting that false is true.

/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:93
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:182
/home/runner/work/api-library/api-library/tests/Api/StagesTest.php:31

4) Mautic\Tests\Api\StagesTest::testCreateGetAndDelete
The response has unexpected status code (400).

Response: {"errors":[{"code":400,"message":"weight: Another stage with this weight already exists.","details":{"weight":["Another stage with this weight already exists."]}}]}

Failed asserting that false is true.

/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:93
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:241
/home/runner/work/api-library/api-library/tests/Api/StagesTest.php:36

5) Mautic\Tests\Api\StagesTest::testEditPatch
The response has unexpected status code (400).

Response: {"errors":[{"code":400,"message":"weight: Another stage with this weight already exists.","details":{"weight":["Another stage with this weight already exists."]}}]}

Failed asserting that false is true.

/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:93
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:108
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:313
/home/runner/work/api-library/api-library/tests/Api/StagesTest.php:44

6) Mautic\Tests\Api\StagesTest::testEditPut
The response has unexpected status code (400).

Response: {"errors":[{"code":400,"message":"weight: Another stage with this weight already exists.","details":{"weight":["Another stage with this weight already exists."]}}]}

Failed asserting that false is true.

/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:93
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:108
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:325
/home/runner/work/api-library/api-library/tests/Api/StagesTest.php:49

7) Mautic\Tests\Api\StagesTest::testAddAndRemove
The response has unexpected status code (400).

Response: {"errors":[{"code":400,"message":"weight: Another stage with this weight already exists.","details":{"weight":["Another stage with this weight already exists."]}}]}

Failed asserting that false is true.

/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:93
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:108
/home/runner/work/api-library/api-library/tests/Api/StagesTest.php:62

8) Mautic\Tests\Api\StagesTest::testBatchEndpoints
weight: Another stage with this weight already exists.; weight: Another stage with this weight already exists.; weight: Another stage with this weight already exists.

Failed asserting that false is true.

/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:93
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:108
/home/runner/work/api-library/api-library/tests/Api/MauticApiTestCase.php:270
/home/runner/work/api-library/api-library/tests/Api/StagesTest.php:84

FAILURES!
Tests: 315, Assertions: 5078, Failures: 8, Skipped: 7.
```
The campaign related failures are addressed in https://github.com/mautic/mautic/pull/16264