### PR TITLE
Remove deprecated formType from Forms API test

### DIFF
--- a/tests/Api/FormsTest.php
+++ b/tests/Api/FormsTest.php
@@ -18,7 +18,6 @@ class FormsTest extends MauticApiTestCase
         $this->api         = $this->getContext('forms');
         $this->testPayload = [
             'name'        => 'test',
-            'formType'    => 'standalone',
             'description' => 'API test',
             'fields'      => [
                 [
@@ -139,9 +138,8 @@ class FormsTest extends MauticApiTestCase
         $response = $this->api->edit(
             $response[$this->api->itemName()]['id'],
             [
-                'name'     => 'test2',
-                'formType' => 'standalone',
-                'fields'   => [
+                'name'   => 'test2',
+                'fields' => [
                     $lastField,
                 ],
                 'actions' => [


### PR DESCRIPTION
## Description

Companion to mautic/mautic#17082, which removes the long-deprecated **form type** from `Mautic\FormBundle\Entity\Form` (deprecated since 7.1, removed in 8.0).

Once core drops the field, `form:read` responses no longer include `formType`. `FormsTest` still sent it in the payload and asserted it back, so it fails against 8.0:

```
Undefined array key "formType"
tests/Api/FormsTest.php:67
```

This drops `formType` from both test payloads.

## Compatibility

Safe against older Mautic too:
- Sending `formType` was already ignored on write (`allow_extra_fields => true`).
- The field was optional, so omitting it changes nothing on pre-8.0 cores.

```diff
             'name'        => 'test',
-            'formType'    => 'standalone',
             'description' => 'API test',
```